### PR TITLE
add: adminログインページのレイアウトとlogin処理の実装

### DIFF
--- a/src/components/AuthAdminCheck.tsx
+++ b/src/components/AuthAdminCheck.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode, useContext, useEffect, useLayoutEffect } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+type AuthProps = {
+  children: ReactNode
+}
+
+const AuthAdminCheck: React.FC<AuthProps> = ({ children }) => {
+  const router = useRouter();
+
+  const { isAuthAdmin } = useContext(AuthContext);
+
+  useEffect(() => {
+    if (!isAuthAdmin) {
+      router.push('/admins/login');
+    }
+  }, [])
+
+
+  return <div>{children}</div>;
+}
+
+export default AuthAdminCheck;

--- a/src/pages/admins/[id]/dashboard.tsx
+++ b/src/pages/admins/[id]/dashboard.tsx
@@ -1,0 +1,60 @@
+import type { NextPage } from "next";
+import Cookies from "js-cookie";
+import axios from "@/lib/axios";
+import { useRouter } from "next/router";
+import { useContext, useEffect } from "react";
+import { AuthContext } from "@/context/AuthContext";
+import AuthAdminCheck from "@/components/AuthAdminCheck";
+
+const UserProfile: NextPage = () => {
+  const router = useRouter();
+  console.log(router.pathname);
+
+  const { isAuthAdmin, setIsAuthAdmin, setAdmin } = useContext(AuthContext);
+
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const logout = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    await csrf();
+
+    await axios.post('/admins/logout', {}, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+      },
+    }).then((res) => {
+      setAdmin({ id: undefined, name: '', email: '' });
+
+      setIsAuthAdmin(false);
+
+      router.push('/admins/login');
+    }).catch(error => {
+      console.log('ログアウトに失敗しました。', error);
+    })
+  }
+
+  return (
+    <>
+      <AuthAdminCheck>
+        {isAuthAdmin && (
+          <>
+            <h1>管理dashboard</h1>
+            <div className="flex flex-col text-center w-full mb-5">
+              <h1 className="text-xl sm:text-2xl font-medium title-font text-gray-900">ログアウト</h1>
+            </div>
+
+            <form onSubmit={logout} className="w-full md:w-4/5 lg:max-w-md mx-auto border rounded-md py-2">
+              <div className="px-2 py-4 w-full">
+                <button type='submit' className="block mx-auto text-white w-3/4 sm:w-2/5 lg:w-2/5 bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-base">ログアウト</button>
+              </div>
+            </form>
+            <h2>チルドレン</h2>
+          </>
+        )}
+      </AuthAdminCheck>
+    </>
+  );
+}
+
+export default UserProfile;

--- a/src/pages/admins/login.tsx
+++ b/src/pages/admins/login.tsx
@@ -1,0 +1,99 @@
+import type { User } from "@/context/AuthContext";
+import type { NextPage } from "next";
+import Cookies from "js-cookie";
+import axios from "@/lib/axios";
+import { useContext, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+const UserLogin: NextPage = () => {
+  const router = useRouter();
+
+  const [email, setEmail] = useState<string>('')
+
+  const [password, setPassword] = useState<string>('')
+
+  type Errors = {
+    email: string[],
+    password: string[]
+  }
+
+  const [errors, setErrors] = useState<Errors>({ email: [], password: [] });
+
+  const { setIsAuthAdmin, setAdmin } = useContext(AuthContext);
+
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const login = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const loginData = {
+      email: email,
+      password: password
+    }
+
+    await csrf();
+
+    await axios.post('/admins/login', loginData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+      }
+    }).then(async (res) => {
+      await axios.get('/api/admin').then(res => {
+
+        const admin: User = res.data;
+
+        setAdmin(admin);
+
+        setIsAuthAdmin(true);
+
+        router.push(`/admins/${admin.id}/dashboard`);
+      })
+    }).catch((e) => {
+      const newErrors = { email: [], password: [], ...e.response.data.errors };
+      setErrors(newErrors);
+
+      console.log('管理者ログインに失敗しました。');
+    })
+  }
+
+  return (
+    <>
+      <div className="container text-gray-600 px-2 sm:px-5 py-5 mx-auto">
+
+        <div className="flex flex-col text-center w-full mb-5">
+          <h1 className="text-xl sm:text-2xl font-medium title-font text-gray-900">管理者用ログイン</h1>
+        </div>
+
+        <form onSubmit={login} className="w-full md:w-4/5 lg:max-w-md mx-auto border rounded-md py-2">
+          <div className="flex flex-col items-center">
+
+            <div className="px-4 py-2 w-full sm:w-3/4 ">
+              <label htmlFor="email" className="leading-7 text-base text-gray-600">email</label>
+              <input type="email" id="email" name="email" onChange={(e) => setEmail(e.target.value)} className="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" />
+              {errors.email.length !== 0 &&
+                errors.email.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+              }
+            </div>
+
+            <div className="px-4 py-2 w-full sm:w-3/4 ">
+              <label htmlFor="password" className="leading-7 text-base text-gray-600">password</label>
+              <input type="password" id="password" name="password" onChange={(e) => setPassword(e.target.value)} className="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" />
+              {errors.password.length !== 0 &&
+                errors.password.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+              }
+            </div>
+
+            <div className="px-2 py-4 w-full">
+              <button type='submit' className="block mx-auto text-white w-3/4 sm:w-2/5 lg:w-2/5 bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-base">ログイン</button>
+            </div>
+
+          </div>
+        </form>
+
+      </div>
+    </>
+  );
+}
+
+export default UserLogin;


### PR DESCRIPTION
やったこと：
- adminログインページのレイアウトの実装
- login処理の実装
- adminとしてログインしていない場合のリダイレクトチェックのCheckAuthAdminコンポーネントの実装
- adminとuserの二種類の認証状態をチェックできるようにAuthContext.tsxのcheckAuthメソッドを編集

レビューお願いします