### PR TITLE
modify: _document.tsxでbody>divタグにmin-h-screenクラスを付与

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,7 @@ export default function Document() {
     <Html lang="en" className='text-[16px] tracking-wide overflow-auto'>
       <Head />
       <body>
-        <div className='overflow-hidden'>
+        <div className='overflow-hidden min-h-screen'>
           <Main />
           <NextScript />
         </div>


### PR DESCRIPTION
overflow:hiddenによるはみ出した部分の非表示による不具合を修正するため
_document.tsxのbody>divにmin-h-screenクラスを設定しました

レビューお願いします。