### PR TITLE
add: gut詳細ページの実装

### DIFF
--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -1,7 +1,138 @@
-const Gut = () =>{
+import type { Gut } from "@/pages/reviews";
+import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
+import { AuthContext } from "@/context/AuthContext";
+import axios from "@/lib/axios";
+import { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import TextUnderBar from "@/components/TextUnderBar";
+import Link from "next/link";
+
+const Gut = () => {
+  const router = useRouter();
+
+  // const id = router.query.id;
+  const [id, setId] = useState(router.query.id)
+
+  const [gut, setGut] = useState<Gut>();
+
+  const [otherGuts, setOtherGuts] = useState<Gut[]>();
+  const otherGutsCount = 5;
+  console.log(otherGuts);
+  const { isAuth, user, setUser, setIsAuth } = useContext(AuthContext);
+
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
+
+
+  useEffect(() => {
+    if (user.id) {
+      const getGut = async () => {
+        await axios.get(`/api/guts/${id}`).then(res => {
+          setGut(res.data);
+        })
+      }
+      const getOtherGuts = async () => {
+        await axios.get(`/api/guts/${id}/others`, {
+          params: { count: otherGutsCount }
+        }).then(res => {
+          setOtherGuts(res.data);
+        })
+      }
+
+      getGut();
+      getOtherGuts();
+    } else {
+      router.push('/users/login');
+    }
+  }, [id])
+
   return (
     <>
-      <h1>ストリング詳細</h1>
+      <AuthCheck>
+        {isAuth && (
+          <>
+            {/* <h1>ストリング詳細</h1> */}
+            <div className="container md:mx-auto">
+              <div className="text-center mb-6">
+                <PrimaryHeading text="String" className="text-[18px] h-[20px]" />
+              </div>
+
+              {/* ガットセクション */}
+              <div className="mb-[64px]">
+
+                <div className="w-[100%] max-w-[320px] mx-auto mb-8">
+                  <div className="flex hover:opacity-80 hover:cursor-pointer">
+                    <div className="w-[120px] mr-6">
+                      {gut?.gut_image.file_path
+                        ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                      }
+                    </div>
+
+                    <div className="w-[100%] max-w-[160px]">
+                      <p className="text-[14px] mb-2">{gut?.maker.name_ja}</p>
+                      <p className="text-[16px] mb-2">{gut?.name_ja}</p>
+                      <TextUnderBar className="w-[100%] max-w-[160px]" />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <div className="w-[100%] max-w-[320px] mx-auto">
+                    <table className="flex flex-row justify-start w-[100%] max-w-[320px]">
+                      <thead className="w-[100%] max-w-[120px]">
+                        <tr className="flex flex-col items-start border-r border-sub-green w-[100%] max-w-[120px]">
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px]">メーカー</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px]">カラー</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px]">ゲージ</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] text-[15px] min-h-[45px] leading-[45px] p-[0px] tracking-tighter">ストリングの種類</th>
+                        </tr>
+
+                      </thead>
+                      <tbody className="w-[100%] max-w-[200px]">
+                        <tr className="flex flex-col items-start w-[100%] max-w-[200px]">
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px]">バボラ</td>
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px]">black/white</td>
+                          <td className="pl-6 min-h-[45px] text-[12px] leading-[45px] p-[0px]">1.20/1.25/1.30/1.25/1.30mm</td>
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px]">ポリエステル</td>
+                        </tr>
+
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+
+              {/* otherガットセクション */}
+              <div className="">
+                <p className="text-[14px] w-[100%] max-w-[320px] mx-auto mb-2">その他のストリング</p>
+                <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
+                  {/* ガット */}
+                  {otherGuts && otherGuts.map(otherGut => (
+                    <Link href={`/guts/${otherGut.id}`} key={otherGut.id} onClick={() => setId(`${otherGut.id}`)} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                      <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {otherGut.gut_image.file_path
+                            ? <img src={`${baseImagePath}${otherGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                          <p className="text-[14px] mb-2 md:text-[16px]">{otherGut.maker.name_ja}</p>
+                          <p className="text-[16px] mb-2 md:text-[18px]">{otherGut.name_ja}</p>
+                          <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                        </div>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </>
+
+        )}
+      </AuthCheck>
     </>
   );
 }

--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -1,28 +1,28 @@
 import type { Gut } from "@/pages/reviews";
-import AuthCheck from "@/components/AuthCheck";
-import PrimaryHeading from "@/components/PrimaryHeading";
-import { AuthContext } from "@/context/AuthContext";
 import axios from "@/lib/axios";
 import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
 import TextUnderBar from "@/components/TextUnderBar";
 import Link from "next/link";
 
 const Gut = () => {
   const router = useRouter();
 
-  // const id = router.query.id;
   const [id, setId] = useState(router.query.id)
 
   const [gut, setGut] = useState<Gut>();
 
   const [otherGuts, setOtherGuts] = useState<Gut[]>();
+
   const otherGutsCount = 5;
-  console.log(otherGuts);
-  const { isAuth, user, setUser, setIsAuth } = useContext(AuthContext);
+
+  const { isAuth, user } = useContext(AuthContext);
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
-
 
   useEffect(() => {
     if (user.id) {
@@ -51,52 +51,49 @@ const Gut = () => {
       <AuthCheck>
         {isAuth && (
           <>
-            {/* <h1>ストリング詳細</h1> */}
             <div className="container md:mx-auto">
-              <div className="text-center mb-6">
-                <PrimaryHeading text="String" className="text-[18px] h-[20px]" />
+              <div className="text-center mb-6 md:mb-[48px]">
+                <PrimaryHeading text="String" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               {/* ガットセクション */}
               <div className="mb-[64px]">
-
-                <div className="w-[100%] max-w-[320px] mx-auto mb-8">
+                <div className="w-[100%] max-w-[320px] mx-auto mb-8 md:max-w-[400px] md:mb-[64px]">
                   <div className="flex hover:opacity-80 hover:cursor-pointer">
-                    <div className="w-[120px] mr-6">
+                    <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
                       {gut?.gut_image.file_path
-                        ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                        ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
+                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
                       }
                     </div>
 
-                    <div className="w-[100%] max-w-[160px]">
-                      <p className="text-[14px] mb-2">{gut?.maker.name_ja}</p>
-                      <p className="text-[16px] mb-2">{gut?.name_ja}</p>
-                      <TextUnderBar className="w-[100%] max-w-[160px]" />
+                    <div className="w-[100%] max-w-[160px] md:max-w-[185px]">
+                      <p className="text-[14px] mb-2 md:text-[16px] md:mb-4">{gut?.maker.name_ja}</p>
+                      <p className="text-[16px] mb-2 md:text-[18px] md:mb-4">{gut?.name_ja}</p>
+                      <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[185px]" />
                     </div>
                   </div>
                 </div>
 
                 <div>
-                  <div className="w-[100%] max-w-[320px] mx-auto">
-                    <table className="flex flex-row justify-start w-[100%] max-w-[320px]">
-                      <thead className="w-[100%] max-w-[120px]">
-                        <tr className="flex flex-col items-start border-r border-sub-green w-[100%] max-w-[120px]">
-                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px]">メーカー</th>
-                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px]">カラー</th>
-                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px]">ゲージ</th>
-                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] text-[15px] min-h-[45px] leading-[45px] p-[0px] tracking-tighter">ストリングの種類</th>
+                  <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[720px]">
+                    <table className="flex flex-row justify-start w-[100%] max-w-[320px] md:flex-col md:max-w-[720px]">
+                      <thead className="w-[100%] max-w-[120px] md:max-w-[720px] md:mb-4">
+                        <tr className="flex flex-col items-start border-r border-sub-green w-[100%] max-w-[120px] md:flex-row md:max-w-[720px] md:border-r-0 md:border-b">
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">メーカー</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">カラー</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">ゲージ</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] tracking-tighter md:text-[16px] md:max-w-[180px]">ストリングの種類</th>
                         </tr>
-
                       </thead>
-                      <tbody className="w-[100%] max-w-[200px]">
-                        <tr className="flex flex-col items-start w-[100%] max-w-[200px]">
-                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px]">バボラ</td>
-                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px]">black/white</td>
-                          <td className="pl-6 min-h-[45px] text-[12px] leading-[45px] p-[0px]">1.20/1.25/1.30/1.25/1.30mm</td>
-                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px]">ポリエステル</td>
-                        </tr>
 
+                      <tbody className="w-[100%] max-w-[200px] md:max-w-[720px]">
+                        <tr className="flex flex-col items-start w-[100%] max-w-[200px] md:flex-row md:max-w-[720px]">
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">{gut?.maker.name_ja}</td>
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">black/white</td>
+                          <td className="pl-6 min-h-[45px] text-[12px] leading-[45px] p-[0px] md:text-[12px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">1.20/1.25/1.30/1.25/1.30mm</td>
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">ポリエステル</td>
+                        </tr>
                       </tbody>
                     </table>
                   </div>
@@ -105,7 +102,7 @@ const Gut = () => {
 
               {/* otherガットセクション */}
               <div className="">
-                <p className="text-[14px] w-[100%] max-w-[320px] mx-auto mb-2">その他のストリング</p>
+                <p className="text-[14px] w-[100%] max-w-[320px] mx-auto mb-2 md:max-w-[768px] md:mb-[16px]">その他のストリング</p>
                 <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
                   {/* ガット */}
                   {otherGuts && otherGuts.map(otherGut => (
@@ -130,7 +127,6 @@ const Gut = () => {
               </div>
             </div>
           </>
-
         )}
       </AuthCheck>
     </>


### PR DESCRIPTION
やったこと：
- spサイズのレイアウトの作成
- pcサイズのレイアウトの作成
- その他のガットの情報取得、表示
- その他のガットクリック時の同ページへの遷移でuseEffectの依存配列にuseStateで管理するようにしたqueryのidを指定し、ページのコンポーネントが再レンダリングされて、表示情報が更新されるようにした。

レビューお願いします。