### PR TITLE
add: 　画像トリミング機能付きgut_image登録画面の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/node": "20.9.1",
         "@types/react": "18.2.37",
         "@types/react-dom": "18.2.15",
+        "@types/react-easy-crop": "^2.0.0",
         "autoprefixer": "10.4.16",
         "axios": "^1.6.2",
         "eslint": "8.54.0",
@@ -21,6 +22,8 @@
         "postcss": "8.4.31",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-easy-crop": "^5.0.2",
+        "react-icons": "^4.12.0",
         "swr": "^2.2.4",
         "tailwindcss": "3.3.5",
         "typescript": "5.2.2"
@@ -413,6 +416,15 @@
       "integrity": "sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-easy-crop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-easy-crop/-/react-easy-crop-2.0.0.tgz",
+      "integrity": "sha512-dUkoNMW3OrXQBYgozC43d3vYPQD23uJFt3ZmM4vcVrj7UjmIc2WxCnO9Zl5fs6bp7StnCtYb3Kp7h7s5T2Xu4w==",
+      "deprecated": "This is a stub types definition. react-easy-crop provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "react-easy-crop": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -2842,6 +2854,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA=="
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3286,6 +3303,32 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.2.tgz",
+      "integrity": "sha512-j4A/0s0v/Gx5YGXvw3SOFIMmRk5YCdob2ABL5cD00Q9HQPKIz6tkCYLdj0RMO0REPtCAOsZ2ZZLI6fUofiDP6w==",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
+      }
+    },
+    "node_modules/react-easy-crop/node_modules/tslib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "20.9.1",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
+    "@types/react-easy-crop": "^2.0.0",
     "autoprefixer": "10.4.16",
     "axios": "^1.6.2",
     "eslint": "8.54.0",
@@ -22,6 +23,8 @@
     "postcss": "8.4.31",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-easy-crop": "^5.0.2",
+    "react-icons": "^4.12.0",
     "swr": "^2.2.4",
     "tailwindcss": "3.3.5",
     "typescript": "5.2.2"

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -91,6 +91,7 @@ const Header: React.FC = () => {
                   <li><Link href={'/my_equipments'} className="mr-4">マイ装備</Link></li>
                   <li><Link href={'/guts'} className="mr-4">ストリング</Link></li>
                   <li><Link href={'/rackets'} className="mr-4">ラケット</Link></li>
+                  <li><Link href={'/gut_images/register'} className="mr-4">ストリング画像提供</Link></li>
                   <li><Link href={`/users/${user.id}/profile`} className="mr-4">マイページ</Link></li>
 
                   <li>
@@ -150,6 +151,7 @@ const Header: React.FC = () => {
                   <li><Link href={'/my_equipments'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">マイ装備</Link></li>
                   <li><Link href={'/guts'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ストリング</Link></li>
                   <li><Link href={'/rackets'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ラケット</Link></li>
+                  <li><Link href={'/gut_images/register'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ストリング画像提供</Link></li>
                   <li><Link href={`/users/${user.id}/profile`} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">マイページ</Link></li>
 
                   <li>

--- a/src/modules/cropImage.ts
+++ b/src/modules/cropImage.ts
@@ -103,8 +103,6 @@ export default async function getCroppedImg(
   //canvas要素をurl->blob->fileにそれぞれ変換してreturn
 
   return new Promise(async (resolve, reject) => {
-
-
     const url: string = croppedCanvas.toDataURL('image/jpeg');
 
     const file: File = await fetch(url)

--- a/src/modules/cropImage.ts
+++ b/src/modules/cropImage.ts
@@ -30,6 +30,11 @@ export function rotateSize(width: number, height: number, rotation: number) {
 /**
  * This function was adapted from the one in the ReadMe of https://github.com/DominicTobias/react-image-crop
  */
+export type CropedImageInfo = {
+  url?: string,
+  file?: File
+}
+
 export default async function getCroppedImg(
   imageSrc: string,
   pixelCrop: Area,
@@ -96,13 +101,21 @@ export default async function getCroppedImg(
 
   // As a blob
   //canvas要素をurl->blob->fileにそれぞれ変換してreturn
+
   return new Promise(async (resolve, reject) => {
+
+
     const url: string = croppedCanvas.toDataURL('image/jpeg');
-    await fetch(url)
+
+    const file: File = await fetch(url)
       .then(response => response.blob())
       .then(blob => new File([blob], 'image.jpg'))
       .then(file => {
-        resolve(file);
+        return file
       })
+
+    const cropedImageInfo: CropedImageInfo = { url, file };
+
+    resolve(cropedImageInfo);
   })
 }

--- a/src/modules/cropImage.ts
+++ b/src/modules/cropImage.ts
@@ -1,0 +1,108 @@
+import type { Area } from "react-easy-crop"
+
+export const createImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener('load', () => resolve(image))
+    image.addEventListener('error', (error) => reject(error))
+    image.setAttribute('crossOrigin', 'anonymous') // needed to avoid cross-origin issues on CodeSandbox
+    image.src = url
+  })
+
+export function getRadianAngle(degreeValue: number) {
+  return (degreeValue * Math.PI) / 180
+}
+
+/**
+ * Returns the new bounding area of a rotated rectangle.
+ */
+export function rotateSize(width: number, height: number, rotation: number) {
+  const rotRad = getRadianAngle(rotation)
+
+  return {
+    width:
+      Math.abs(Math.cos(rotRad) * width) + Math.abs(Math.sin(rotRad) * height),
+    height:
+      Math.abs(Math.sin(rotRad) * width) + Math.abs(Math.cos(rotRad) * height),
+  }
+}
+
+/**
+ * This function was adapted from the one in the ReadMe of https://github.com/DominicTobias/react-image-crop
+ */
+export default async function getCroppedImg(
+  imageSrc: string,
+  pixelCrop: Area,
+  rotation = 0,
+  flip = { horizontal: false, vertical: false }
+) {
+  const image = await createImage(imageSrc)
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+
+  if (!ctx) {
+    return null
+  }
+
+  const rotRad = getRadianAngle(rotation)
+
+  // calculate bounding box of the rotated image
+  const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+    image.width,
+    image.height,
+    rotation
+  )
+
+  // set canvas size to match the bounding box
+  canvas.width = bBoxWidth
+  canvas.height = bBoxHeight
+
+  // translate canvas context to a central location to allow rotating and flipping around the center
+  ctx.translate(bBoxWidth / 2, bBoxHeight / 2)
+  ctx.rotate(rotRad)
+  ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1)
+  ctx.translate(-image.width / 2, -image.height / 2)
+
+  // draw rotated image
+  ctx.drawImage(image, 0, 0)
+
+  const croppedCanvas: HTMLCanvasElement = document.createElement('canvas')
+
+  const croppedCtx = croppedCanvas.getContext('2d')
+
+  if (!croppedCtx) {
+    return null
+  }
+
+  // Set the size of the cropped canvas
+  croppedCanvas.width = pixelCrop ? pixelCrop.width : image.width
+  croppedCanvas.height = pixelCrop ? pixelCrop.height : image.height
+
+  // Draw the cropped image onto the new canvas
+  croppedCtx.drawImage(
+    canvas,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height
+  )
+
+  // As Base64 string
+  // return croppedCanvas.toDataURL('image/jpeg');
+
+  // As a blob
+  //canvas要素をurl->blob->fileにそれぞれ変換してreturn
+  return new Promise(async (resolve, reject) => {
+    const url: string = croppedCanvas.toDataURL('image/jpeg');
+    await fetch(url)
+      .then(response => response.blob())
+      .then(blob => new File([blob], 'image.jpg'))
+      .then(file => {
+        resolve(file);
+      })
+  })
+}

--- a/src/pages/gut_images/index.tsx
+++ b/src/pages/gut_images/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const GutImageList: React.FC = () => {
+
+  return (
+    <>
+      <h1>ストリング画像一覧</h1>
+    </>
+  );
+}
+
+export default GutImageList;

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -1,16 +1,72 @@
 import AuthCheck from "@/components/AuthCheck";
 import { AuthContext } from "@/context/AuthContext";
 import { NextPage } from "next";
-import { useContext } from "react";
+import { useContext, useState } from "react";
+// import ModalSpSize from "@/components/ModalSpSize";
+import CloseIcon from "@/components/CloseIcon";
+import axios from "@/lib/axios";
 
 const GutImageRegister: NextPage = () => {
   const { isAuth, user } = useContext(AuthContext);
+
+  const [imageFile, setImageFile] = useState<File | null>();
+  console.log('imageFile', imageFile);
+
+  const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (files && files[0]) {
+      setImageFile(files[0])
+    }
+    console.log(imageFile);
+  }
+
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+  
+
+  // const [showingModal, setShowingModal] = useState<boolean>(false);
+
+  // const toggleModal = () => {
+  //   setShowingModal(prev => !prev);
+  // }
+  
   return (
     <>
       <AuthCheck>
         {isAuth && (
           <>
             <h1>ストリング画像登録</h1>
+
+            <div className="container mx-auto">
+
+
+              <div>
+                <form action="">
+                  {/* <label htmlFor="gut_image_file"></label>
+                  <input type="file" name="gut_image" id="gut_image" onChange={} /> */}
+
+                  <div className="flex flex-col mb-6">
+                      <label htmlFor="gut_image_file">ストリング画像ファイル</label>
+                      <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
+                      {/* {errors.file.length !== 0 &&
+                        errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                    </div>
+                </form>
+              </div>
+
+              {/* //モーダル */}
+              {/* <div className="h-screen bg-sub-gray bg-opacity-30">
+                <div className="pt-6">
+                  <div className="flex justify-end w-[100%] max-w-[320px] mx-auto">
+                    <span className="inline-block" onClick={toggleModal}>
+                      <CloseIcon size={32} />
+                    </span>
+                  </div>
+                </div>
+              </div> */}
+
+            </div>
+            
           </>
         )}
       </AuthCheck>

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -5,30 +5,112 @@ import { useContext, useState } from "react";
 // import ModalSpSize from "@/components/ModalSpSize";
 import CloseIcon from "@/components/CloseIcon";
 import axios from "@/lib/axios";
+import Cookies from "js-cookie";
+
+import Cropper, { type Point, Area } from "react-easy-crop";
+import getCroppedImg from "@/modules/cropImage";
+import { useRouter } from "next/router";
 
 const GutImageRegister: NextPage = () => {
+  const router = useRouter();
+
   const { isAuth, user } = useContext(AuthContext);
 
-  const [imageFile, setImageFile] = useState<File | null>();
-  console.log('imageFile', imageFile);
+  const [title, setTitle] = useState<string>('');
+  console.log('title', title);
+
+  const [imageFileUrl, setImageFileUrl] = useState<string>('');
+  console.log(imageFileUrl);
 
   const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
     if (files && files[0]) {
-      setImageFile(files[0])
+      const reader = new FileReader();
+
+      reader.addEventListener('load', () => {
+        if (reader.result) {
+          setImageFileUrl(reader.result.toString() || '');
+        }
+      })
+      reader.readAsDataURL(files[0]);
     }
-    console.log(imageFile);
   }
 
-  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
-  
+
+
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [rotation, setRotation] = useState(0)
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>()
+  const [croppedImage, setCroppedImage] = useState<File>();
+  console.log('state cropppedImage', croppedImage);
+
+
+  const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
+    // console.log(croppedArea, croppedAreaPixels);
+    setCroppedAreaPixels(croppedAreaPixels)
+  };
+
+  const showCroppedImage = async () => {
+    try {
+      const croppedImage: File = await getCroppedImg(
+        imageFileUrl,
+        croppedAreaPixels as Area,
+        rotation
+      ) as File
+
+      console.log('型', typeof (croppedImage), croppedImage);
+      setCroppedImage(croppedImage)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const onClose = () => {
+    setCroppedImage(undefined);
+  }
+
 
   // const [showingModal, setShowingModal] = useState<boolean>(false);
 
   // const toggleModal = () => {
   //   setShowingModal(prev => !prev);
   // }
-  
+
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const uploadGutImage = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const registerData = {
+      file: croppedImage,
+      title: title,
+    }
+
+    await csrf();
+
+    await axios.post('api/gut_images', registerData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+        'Content-Type': 'multipart/form-data;'
+      }
+    }).then(async (res) => {
+      setCroppedImage(undefined);
+      setCrop({ x: 0, y: 0 });
+      setRotation(0);
+      setZoom(1);
+      setCroppedAreaPixels(undefined);
+      setTitle('');
+      console.log('ストリング画像を登録しました');
+    }).catch((e) => {
+      console.log(e);
+      // const newErrors = {name: [], email: [], password: [], file: [], ...e.response.data.errors };
+      // setErrors(newErrors);
+
+      console.log('基本プロフィール更新に失敗しました。');
+    })
+  }
+
   return (
     <>
       <AuthCheck>
@@ -40,17 +122,87 @@ const GutImageRegister: NextPage = () => {
 
 
               <div>
-                <form action="">
-                  {/* <label htmlFor="gut_image_file"></label>
-                  <input type="file" name="gut_image" id="gut_image" onChange={} /> */}
+                <form action="" onSubmit={uploadGutImage}>
+                  <div className="mb-6">
+                    <label htmlFor="title" className="block">タイトル</label>
+                    <input type="text" name="title" onChange={(e) => setTitle(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
+                    {/* {errors.name.length !== 0 &&
+                        errors.name.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                  </div>
 
                   <div className="flex flex-col mb-6">
-                      <label htmlFor="gut_image_file">ストリング画像ファイル</label>
-                      <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
-                      {/* {errors.file.length !== 0 &&
+                    <label htmlFor="gut_image_file">ストリング画像ファイル</label>
+                    <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
+                    {/* {errors.file.length !== 0 &&
                         errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       } */}
-                    </div>
+                  </div>
+
+                  {imageFileUrl && (
+                    <>
+                      <div>
+                        <p>画像トリミング</p>
+                        <div className="h-[300px] relative ">
+                          <Cropper
+                            image={imageFileUrl}
+                            crop={crop}
+                            rotation={rotation}
+                            zoom={zoom}
+                            aspect={1 / 1}
+                            onCropChange={setCrop}
+                            onRotationChange={setRotation}
+                            onCropComplete={onCropComplete}
+                            onZoomChange={setZoom}
+                          />
+                        </div>
+
+                        <div className="flex justify-center">
+                          ズーム：
+                          <input
+                            type="range"
+                            value={zoom}
+                            min={1}
+                            max={3}
+                            step={0.1}
+                            aria-labelledby="Zoom"
+                            onChange={(e) => {
+                              setZoom(Number(e.target.value))
+                            }}
+                            className="zoom-range"
+                          />
+                        </div>
+
+                        <div className="flex justify-center mt-6">
+                          回転：
+                          <input
+                            type="range"
+                            value={rotation}
+                            min={0}
+                            max={360}
+                            step={0.5}
+                            aria-labelledby="Rotation"
+                            onChange={(e) => {
+                              setRotation(Number(e.target.value))
+                            }}
+                            className="zoom-range"
+                          />
+                        </div>
+
+                        <div>
+                          <p onClick={showCroppedImage} className="inline-block border p-2">トリミングを完了</p>
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+
+                  <div>
+                    {croppedImage &&
+                      <button type="submit" className="border p-2">画像を追加する</button>
+                    }
+                  </div>
+
                 </form>
               </div>
 
@@ -66,10 +218,10 @@ const GutImageRegister: NextPage = () => {
               </div> */}
 
             </div>
-            
+
           </>
         )}
-      </AuthCheck>
+      </AuthCheck >
     </>
   );
 }

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -1,15 +1,15 @@
-import AuthCheck from "@/components/AuthCheck";
-import { AuthContext } from "@/context/AuthContext";
-import { NextPage } from "next";
-import { useContext, useState } from "react";
-// import ModalSpSize from "@/components/ModalSpSize";
-import CloseIcon from "@/components/CloseIcon";
+import type { NextPage } from "next";
+
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
-
 import Cropper, { type Point, Area } from "react-easy-crop";
 import getCroppedImg, { CropedImageInfo } from "@/modules/cropImage";
+
+import { useContext, useState } from "react";
 import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthCheck from "@/components/AuthCheck";
 import PrimaryHeading from "@/components/PrimaryHeading";
 
 const GutImageRegister: NextPage = () => {
@@ -18,10 +18,8 @@ const GutImageRegister: NextPage = () => {
   const { isAuth, user } = useContext(AuthContext);
 
   const [title, setTitle] = useState<string>('');
-  console.log('title', title);
 
   const [imageFileUrl, setImageFileUrl] = useState<string>('');
-  console.log(imageFileUrl);
 
   const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
@@ -37,26 +35,19 @@ const GutImageRegister: NextPage = () => {
     }
   }
 
-
-
   const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
   const [rotation, setRotation] = useState(0)
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>()
   const [croppedImage, setCroppedImage] = useState<File>();
   const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
-  console.log('state cropppedImage', croppedImage);
-  console.log('croppedImageUrl', croppedImageUrl);
-
 
   const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
-    // console.log(croppedArea, croppedAreaPixels);
     setCroppedAreaPixels(croppedAreaPixels)
   };
 
   const showCroppedImage = async () => {
     try {
-      // const croppedImage: File = await getCroppedImg(
       const cropedImageInfo: CropedImageInfo = await getCroppedImg(
         imageFileUrl,
         croppedAreaPixels as Area,
@@ -67,20 +58,9 @@ const GutImageRegister: NextPage = () => {
 
       const croppedImageUrl = cropedImageInfo.url
 
-      console.log('型', typeof (croppedImage), croppedImage);
-
       setCroppedImage(croppedImage);
 
       setCroppedImageUrl(croppedImageUrl);
-
-      // const croppedImage: File = await getCroppedImg(
-      //   imageFileUrl,
-      //   croppedAreaPixels as Area,
-      //   rotation
-      // ) as File
-
-      // console.log('型', typeof (croppedImage), croppedImage);
-      // setCroppedImage(croppedImage)
     } catch (e) {
       console.error(e)
     }
@@ -90,12 +70,13 @@ const GutImageRegister: NextPage = () => {
     setCroppedImage(undefined);
   }
 
+  type Errors = {
+    title: string[],
+    file: string[]
+  }
 
-  // const [showingModal, setShowingModal] = useState<boolean>(false);
+  const [errors, setErrors] = useState<Errors>({ title: [], file: [] });
 
-  // const toggleModal = () => {
-  //   setShowingModal(prev => !prev);
-  // }
 
   const csrf = async () => await axios.get('/sanctum/csrf-cookie');
 
@@ -115,17 +96,13 @@ const GutImageRegister: NextPage = () => {
         'Content-Type': 'multipart/form-data;'
       }
     }).then(async (res) => {
-      setCroppedImage(undefined);
-      setCrop({ x: 0, y: 0 });
-      setRotation(0);
-      setZoom(1);
-      setCroppedAreaPixels(undefined);
-      setTitle('');
       console.log('ストリング画像を登録しました');
+
+      router.push('/gut_images');
     }).catch((e) => {
       console.log(e);
-      // const newErrors = {name: [], email: [], password: [], file: [], ...e.response.data.errors };
-      // setErrors(newErrors);
+      const newErrors = { title: [], file: [], ...e.response.data.errors };
+      setErrors(newErrors);
 
       console.log('基本プロフィール更新に失敗しました。');
     })
@@ -136,36 +113,34 @@ const GutImageRegister: NextPage = () => {
       <AuthCheck>
         {isAuth && (
           <>
-            {/* <h1>ストリング画像登録</h1> */}
-
             <div className="container mx-auto mb-[48px]">
-              <div className="text-center mb-6">
+              <div className="text-center mb-6 md:mb-[48px]">
                 <PrimaryHeading text="ストリング画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               <div>
-                <div className="w-[100%] max-w-[320px] mx-auto">
+                <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[380px]">
                   <form action="" onSubmit={uploadGutImage}>
                     <div className="mb-6">
-                      <label htmlFor="title" className="block">画像タイトル</label>
+                      <label htmlFor="title" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">画像タイトル</label>
                       <input type="text" name="title" onChange={(e) => setTitle(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
-                      {/* {errors.name.length !== 0 &&
-                        errors.name.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
+                      {errors.title.length !== 0 &&
+                        errors.title.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
                     </div>
 
                     <div className="flex flex-col mb-6">
-                      <label htmlFor="gut_image_file">画像ファイル</label>
+                      <label htmlFor="gut_image_file" className="text-[14px] mb-1 md:text-[16px] md:mb-2">画像ファイル</label>
                       <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
-                      {/* {errors.file.length !== 0 &&
+                      {errors.file.length !== 0 &&
                         errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
+                      }
                     </div>
 
                     {/* トリミングエリア */}
                     <div className="mb-6 ">
                       <p>画像トリミング</p>
-                      <div className="border-t rounded min-h-[40px]">
+                      <div className="border-t rounded min-h-[40px] w-[100%] max-w-[320px] md:max-w-[380px]">
 
                         {imageFileUrl && (
                           <>
@@ -184,7 +159,7 @@ const GutImageRegister: NextPage = () => {
                             </div>
 
                             <div className="flex justify-start w-[100%] max-w-[288px] mx-auto mb-8">
-                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px]">ズーム：</span>
+                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]">ズーム：</span>
                               <input
                                 type="range"
                                 value={zoom}
@@ -195,13 +170,13 @@ const GutImageRegister: NextPage = () => {
                                 onChange={(e) => {
                                   setZoom(Number(e.target.value))
                                 }}
-                                className="inline-block h-[16px] w-[100%] max-w-[220px]"
+                                className="inline-block h-[16px] w-[100%] max-w-[220px] md:h-[18px]"
                               />
                             </div>
 
                             <div className="flex justify-center mt-6 mb-[40px]">
 
-                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px]" >回転：</span>
+                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]" >回転：</span>
                               <input
                                 type="range"
                                 value={rotation}
@@ -212,52 +187,50 @@ const GutImageRegister: NextPage = () => {
                                 onChange={(e) => {
                                   setRotation(Number(e.target.value))
                                 }}
-                                className="inline-block h-[16px] w-[100%] max-w-[220px]"
+                                className="inline-block h-[16px] w-[100%] max-w-[220px] md:h-[18px]"
                               />
                             </div>
 
                             <div className="flex justify-end">
-                              <p onClick={showCroppedImage} className="inline-block border  hover:cursor-pointer hover:opacity-60 font-semibold text-white text-[14px] w-[192px] h-8 rounded  bg-sub-green text-center leading-[32px]">トリミングを完了</p>
+                              <p onClick={showCroppedImage} className="inline-block border  hover:cursor-pointer hover:opacity-60 font-semibold text-white text-[14px] w-[192px] h-8 rounded  bg-sub-green text-center leading-[32px] md:text-[16px]">トリミングを完了</p>
                             </div>
                           </>
                         )}
                       </div>
                     </div>
 
-                    <div className="mb-[64px]">
-                      {croppedImageUrl && (
-                        <>
-                          <p className="text-[14px] mb-1">プレビュー</p>
-                          <img src={croppedImageUrl} alt="" className="w-[100%] max-w-[160px]" />
-                        </>
+                    <div className="md:flex justify-between items-start md:w-[100%] md:max-w-[380px] ">
+                      {/* プレビュー */}
+                      <div className="mb-[64px] md:mb-0">
+                        {croppedImageUrl && (
+                          <>
+                            <p className="text-[14px] mb-1 md:text-[16px] md:mb-2">プレビュー</p>
+                            <img src={croppedImageUrl} alt="" className="w-[100%] max-w-[160px] md:max-w-[180px]" />
+                          </>
+                        )}
+                      </div>
 
-                      )}
+
+                      <div className="flex justify-center md:mt-[32px]">
+                        {croppedImage && (
+                          <>
+                            <div>
+                              <button type="submit" className="text-white text-[14px] w-[200px] h-8 rounded  bg-sub-green md:w-[150px] md:text-[16px] md:block md:ml-auto">画像を追加する</button>
+                              {errors.title.length !== 0 &&
+                                errors.title.map((message, i) => <p key={i} className="text-red-400 mt-2">{message}</p>)
+                              }
+                              {errors.file.length !== 0 &&
+                                errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                              }
+                            </div>
+                          </>
+                        )}
+                      </div>
                     </div>
-
-
-                    <div className="flex justify-center ">
-                      {croppedImage &&
-                        <button type="submit" className="text-white text-[14px] w-[200px] h-8 rounded  bg-sub-green">画像を追加する</button>
-                      }
-                    </div>
-
                   </form>
                 </div>
               </div>
-
-              {/* //モーダル */}
-              {/* <div className="h-screen bg-sub-gray bg-opacity-30">
-                <div className="pt-6">
-                  <div className="flex justify-end w-[100%] max-w-[320px] mx-auto">
-                    <span className="inline-block" onClick={toggleModal}>
-                      <CloseIcon size={32} />
-                    </span>
-                  </div>
-                </div>
-              </div> */}
-
             </div>
-
           </>
         )}
       </AuthCheck >

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -1,0 +1,21 @@
+import AuthCheck from "@/components/AuthCheck";
+import { AuthContext } from "@/context/AuthContext";
+import { NextPage } from "next";
+import { useContext } from "react";
+
+const GutImageRegister: NextPage = () => {
+  const { isAuth, user } = useContext(AuthContext);
+  return (
+    <>
+      <AuthCheck>
+        {isAuth && (
+          <>
+            <h1>ストリング画像登録</h1>
+          </>
+        )}
+      </AuthCheck>
+    </>
+  );
+}
+
+export default GutImageRegister;

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -8,8 +8,9 @@ import axios from "@/lib/axios";
 import Cookies from "js-cookie";
 
 import Cropper, { type Point, Area } from "react-easy-crop";
-import getCroppedImg from "@/modules/cropImage";
+import getCroppedImg, { CropedImageInfo } from "@/modules/cropImage";
 import { useRouter } from "next/router";
+import PrimaryHeading from "@/components/PrimaryHeading";
 
 const GutImageRegister: NextPage = () => {
   const router = useRouter();
@@ -43,7 +44,9 @@ const GutImageRegister: NextPage = () => {
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>()
   const [croppedImage, setCroppedImage] = useState<File>();
+  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
   console.log('state cropppedImage', croppedImage);
+  console.log('croppedImageUrl', croppedImageUrl);
 
 
   const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
@@ -53,14 +56,31 @@ const GutImageRegister: NextPage = () => {
 
   const showCroppedImage = async () => {
     try {
-      const croppedImage: File = await getCroppedImg(
+      // const croppedImage: File = await getCroppedImg(
+      const cropedImageInfo: CropedImageInfo = await getCroppedImg(
         imageFileUrl,
         croppedAreaPixels as Area,
         rotation
-      ) as File
+      ) as CropedImageInfo
+
+      const croppedImage = cropedImageInfo.file;
+
+      const croppedImageUrl = cropedImageInfo.url
 
       console.log('型', typeof (croppedImage), croppedImage);
-      setCroppedImage(croppedImage)
+
+      setCroppedImage(croppedImage);
+
+      setCroppedImageUrl(croppedImageUrl);
+
+      // const croppedImage: File = await getCroppedImg(
+      //   imageFileUrl,
+      //   croppedAreaPixels as Area,
+      //   rotation
+      // ) as File
+
+      // console.log('型', typeof (croppedImage), croppedImage);
+      // setCroppedImage(croppedImage)
     } catch (e) {
       console.error(e)
     }
@@ -116,94 +136,113 @@ const GutImageRegister: NextPage = () => {
       <AuthCheck>
         {isAuth && (
           <>
-            <h1>ストリング画像登録</h1>
+            {/* <h1>ストリング画像登録</h1> */}
 
-            <div className="container mx-auto">
-
+            <div className="container mx-auto mb-[48px]">
+              <div className="text-center mb-6">
+                <PrimaryHeading text="ストリング画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
 
               <div>
-                <form action="" onSubmit={uploadGutImage}>
-                  <div className="mb-6">
-                    <label htmlFor="title" className="block">タイトル</label>
-                    <input type="text" name="title" onChange={(e) => setTitle(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
-                    {/* {errors.name.length !== 0 &&
+                <div className="w-[100%] max-w-[320px] mx-auto">
+                  <form action="" onSubmit={uploadGutImage}>
+                    <div className="mb-6">
+                      <label htmlFor="title" className="block">画像タイトル</label>
+                      <input type="text" name="title" onChange={(e) => setTitle(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
+                      {/* {errors.name.length !== 0 &&
                         errors.name.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       } */}
-                  </div>
+                    </div>
 
-                  <div className="flex flex-col mb-6">
-                    <label htmlFor="gut_image_file">ストリング画像ファイル</label>
-                    <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
-                    {/* {errors.file.length !== 0 &&
+                    <div className="flex flex-col mb-6">
+                      <label htmlFor="gut_image_file">画像ファイル</label>
+                      <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
+                      {/* {errors.file.length !== 0 &&
                         errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       } */}
-                  </div>
+                    </div>
 
-                  {imageFileUrl && (
-                    <>
-                      <div>
-                        <p>画像トリミング</p>
-                        <div className="h-[300px] relative ">
-                          <Cropper
-                            image={imageFileUrl}
-                            crop={crop}
-                            rotation={rotation}
-                            zoom={zoom}
-                            aspect={1 / 1}
-                            onCropChange={setCrop}
-                            onRotationChange={setRotation}
-                            onCropComplete={onCropComplete}
-                            onZoomChange={setZoom}
-                          />
-                        </div>
+                    {/* トリミングエリア */}
+                    <div className="mb-6 ">
+                      <p>画像トリミング</p>
+                      <div className="border-t rounded min-h-[40px]">
 
-                        <div className="flex justify-center">
-                          ズーム：
-                          <input
-                            type="range"
-                            value={zoom}
-                            min={1}
-                            max={3}
-                            step={0.1}
-                            aria-labelledby="Zoom"
-                            onChange={(e) => {
-                              setZoom(Number(e.target.value))
-                            }}
-                            className="zoom-range"
-                          />
-                        </div>
+                        {imageFileUrl && (
+                          <>
+                            <div className="h-[300px] relative mb-8">
+                              <Cropper
+                                image={imageFileUrl}
+                                crop={crop}
+                                rotation={rotation}
+                                zoom={zoom}
+                                aspect={1 / 1}
+                                onCropChange={setCrop}
+                                onRotationChange={setRotation}
+                                onCropComplete={onCropComplete}
+                                onZoomChange={setZoom}
+                              />
+                            </div>
 
-                        <div className="flex justify-center mt-6">
-                          回転：
-                          <input
-                            type="range"
-                            value={rotation}
-                            min={0}
-                            max={360}
-                            step={0.5}
-                            aria-labelledby="Rotation"
-                            onChange={(e) => {
-                              setRotation(Number(e.target.value))
-                            }}
-                            className="zoom-range"
-                          />
-                        </div>
+                            <div className="flex justify-start w-[100%] max-w-[288px] mx-auto mb-8">
+                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px]">ズーム：</span>
+                              <input
+                                type="range"
+                                value={zoom}
+                                min={1}
+                                max={3}
+                                step={0.1}
+                                aria-labelledby="Zoom"
+                                onChange={(e) => {
+                                  setZoom(Number(e.target.value))
+                                }}
+                                className="inline-block h-[16px] w-[100%] max-w-[220px]"
+                              />
+                            </div>
 
-                        <div>
-                          <p onClick={showCroppedImage} className="inline-block border p-2">トリミングを完了</p>
-                        </div>
+                            <div className="flex justify-center mt-6 mb-[40px]">
+
+                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px]" >回転：</span>
+                              <input
+                                type="range"
+                                value={rotation}
+                                min={0}
+                                max={360}
+                                step={0.5}
+                                aria-labelledby="Rotation"
+                                onChange={(e) => {
+                                  setRotation(Number(e.target.value))
+                                }}
+                                className="inline-block h-[16px] w-[100%] max-w-[220px]"
+                              />
+                            </div>
+
+                            <div className="flex justify-end">
+                              <p onClick={showCroppedImage} className="inline-block border  hover:cursor-pointer hover:opacity-60 font-semibold text-white text-[14px] w-[192px] h-8 rounded  bg-sub-green text-center leading-[32px]">トリミングを完了</p>
+                            </div>
+                          </>
+                        )}
                       </div>
-                    </>
-                  )}
+                    </div>
+
+                    <div className="mb-[64px]">
+                      {croppedImageUrl && (
+                        <>
+                          <p className="text-[14px] mb-1">プレビュー</p>
+                          <img src={croppedImageUrl} alt="" className="w-[100%] max-w-[160px]" />
+                        </>
+
+                      )}
+                    </div>
 
 
-                  <div>
-                    {croppedImage &&
-                      <button type="submit" className="border p-2">画像を追加する</button>
-                    }
-                  </div>
+                    <div className="flex justify-center ">
+                      {croppedImage &&
+                        <button type="submit" className="text-white text-[14px] w-[200px] h-8 rounded  bg-sub-green">画像を追加する</button>
+                      }
+                    </div>
 
-                </form>
+                  </form>
+                </div>
               </div>
 
               {/* //モーダル */}


### PR DESCRIPTION
やったこと：
- react-easy-cropを用いた画像トリミング機能の実装
- トリミング後にFile型とURLを受け取りプレビューを表示させ、確認後サーバーへ登録処理を投げる機能を実装
- spサイズのレイアウトの実装
- pcサイズのレイアウトの実装
- error時のエラーメッセージの表示

レビューお願い時ます