### PR TITLE
add: トリミング機能付きracket_image登録ページの実装

### DIFF
--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -92,6 +92,7 @@ const Header: React.FC = () => {
                   <li><Link href={'/guts'} className="mr-4">ストリング</Link></li>
                   <li><Link href={'/rackets'} className="mr-4">ラケット</Link></li>
                   <li><Link href={'/gut_images/register'} className="mr-4">ストリング画像提供</Link></li>
+                  <li><Link href={'/racket_images/register'} className="mr-4">ラケット画像提供</Link></li>
                   <li><Link href={`/users/${user.id}/profile`} className="mr-4">マイページ</Link></li>
 
                   <li>
@@ -152,6 +153,7 @@ const Header: React.FC = () => {
                   <li><Link href={'/guts'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ストリング</Link></li>
                   <li><Link href={'/rackets'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ラケット</Link></li>
                   <li><Link href={'/gut_images/register'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ストリング画像提供</Link></li>
+                  <li><Link href={'/racket_images/register'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ラケット画像提供</Link></li>
                   <li><Link href={`/users/${user.id}/profile`} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">マイページ</Link></li>
 
                   <li>

--- a/src/pages/racket_images/index.tsx
+++ b/src/pages/racket_images/index.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from "next";
+
+
+const RacktImageList: NextPage = () => {
+  return (
+    <>
+      <h1>ラケット画像一覧ページ</h1>
+    </>
+  );
+}
+
+export default RacktImageList;

--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -90,21 +90,21 @@ const GutImageRegister: NextPage = () => {
 
     await csrf();
 
-    await axios.post('api/gut_images', registerData, {
+    await axios.post('api/racket_images', registerData, {
       headers: {
         'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
         'Content-Type': 'multipart/form-data;'
       }
     }).then(async (res) => {
-      console.log('ストリング画像を登録しました');
+      console.log('ラケット画像を登録しました');
 
-      router.push('/gut_images');
+      router.push('/racket_images');
     }).catch((e) => {
       console.log(e);
       const newErrors = { title: [], file: [], ...e.response.data.errors };
       setErrors(newErrors);
 
-      console.log('基本プロフィール更新に失敗しました。');
+      console.log('ラケット画像登録に失敗しました。');
     })
   }
 
@@ -115,7 +115,7 @@ const GutImageRegister: NextPage = () => {
           <>
             <div className="container mx-auto mb-[48px]">
               <div className="text-center mb-6 md:mb-[48px]">
-                <PrimaryHeading text="ストリング画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+                <PrimaryHeading text="ラケット画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               <div>
@@ -150,7 +150,7 @@ const GutImageRegister: NextPage = () => {
                                 crop={crop}
                                 rotation={rotation}
                                 zoom={zoom}
-                                aspect={1 / 1}
+                                aspect={3 / 4}
                                 onCropChange={setCrop}
                                 onRotationChange={setRotation}
                                 onCropComplete={onCropComplete}

--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -1,19 +1,241 @@
-import AuthCheck from "@/components/AuthCheck";
-import { AuthContext } from "@/context/AuthContext";
-import { NextPage } from "next";
-import { useContext } from "react";
+import type { NextPage } from "next";
 
-const RacketImageRegister: NextPage = () => {
+import axios from "@/lib/axios";
+import Cookies from "js-cookie";
+import Cropper, { type Point, Area } from "react-easy-crop";
+import getCroppedImg, { CropedImageInfo } from "@/modules/cropImage";
+
+import { useContext, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
+
+const GutImageRegister: NextPage = () => {
+  const router = useRouter();
+
   const { isAuth, user } = useContext(AuthContext);
+
+  const [title, setTitle] = useState<string>('');
+
+  const [imageFileUrl, setImageFileUrl] = useState<string>('');
+
+  const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (files && files[0]) {
+      const reader = new FileReader();
+
+      reader.addEventListener('load', () => {
+        if (reader.result) {
+          setImageFileUrl(reader.result.toString() || '');
+        }
+      })
+      reader.readAsDataURL(files[0]);
+    }
+  }
+
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [rotation, setRotation] = useState(0)
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>()
+  const [croppedImage, setCroppedImage] = useState<File>();
+  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
+
+  const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
+    setCroppedAreaPixels(croppedAreaPixels)
+  };
+
+  const showCroppedImage = async () => {
+    try {
+      const cropedImageInfo: CropedImageInfo = await getCroppedImg(
+        imageFileUrl,
+        croppedAreaPixels as Area,
+        rotation
+      ) as CropedImageInfo
+
+      const croppedImage = cropedImageInfo.file;
+
+      const croppedImageUrl = cropedImageInfo.url
+
+      setCroppedImage(croppedImage);
+
+      setCroppedImageUrl(croppedImageUrl);
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const onClose = () => {
+    setCroppedImage(undefined);
+  }
+
+  type Errors = {
+    title: string[],
+    file: string[]
+  }
+
+  const [errors, setErrors] = useState<Errors>({ title: [], file: [] });
+
+
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const uploadGutImage = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const registerData = {
+      file: croppedImage,
+      title: title,
+    }
+
+    await csrf();
+
+    await axios.post('api/gut_images', registerData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+        'Content-Type': 'multipart/form-data;'
+      }
+    }).then(async (res) => {
+      console.log('ストリング画像を登録しました');
+
+      router.push('/gut_images');
+    }).catch((e) => {
+      console.log(e);
+      const newErrors = { title: [], file: [], ...e.response.data.errors };
+      setErrors(newErrors);
+
+      console.log('基本プロフィール更新に失敗しました。');
+    })
+  }
+
   return (
     <>
       <AuthCheck>
         {isAuth && (
-          <h1>ラケット登録ページ</h1>
+          <>
+            <div className="container mx-auto mb-[48px]">
+              <div className="text-center mb-6 md:mb-[48px]">
+                <PrimaryHeading text="ストリング画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
+
+              <div>
+                <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[380px]">
+                  <form action="" onSubmit={uploadGutImage}>
+                    <div className="mb-6">
+                      <label htmlFor="title" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">画像タイトル</label>
+                      <input type="text" name="title" onChange={(e) => setTitle(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
+                      {errors.title.length !== 0 &&
+                        errors.title.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+
+                    <div className="flex flex-col mb-6">
+                      <label htmlFor="gut_image_file" className="text-[14px] mb-1 md:text-[16px] md:mb-2">画像ファイル</label>
+                      <input type="file" name="gut_image_file" accept=".jpg, .jpeg, .png" onChange={onChangeFile} className="h-8" />
+                      {errors.file.length !== 0 &&
+                        errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+
+                    {/* トリミングエリア */}
+                    <div className="mb-6 ">
+                      <p>画像トリミング</p>
+                      <div className="border-t rounded min-h-[40px] w-[100%] max-w-[320px] md:max-w-[380px]">
+
+                        {imageFileUrl && (
+                          <>
+                            <div className="h-[300px] relative mb-8">
+                              <Cropper
+                                image={imageFileUrl}
+                                crop={crop}
+                                rotation={rotation}
+                                zoom={zoom}
+                                aspect={1 / 1}
+                                onCropChange={setCrop}
+                                onRotationChange={setRotation}
+                                onCropComplete={onCropComplete}
+                                onZoomChange={setZoom}
+                              />
+                            </div>
+
+                            <div className="flex justify-start w-[100%] max-w-[288px] mx-auto mb-8">
+                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]">ズーム：</span>
+                              <input
+                                type="range"
+                                value={zoom}
+                                min={1}
+                                max={3}
+                                step={0.1}
+                                aria-labelledby="Zoom"
+                                onChange={(e) => {
+                                  setZoom(Number(e.target.value))
+                                }}
+                                className="inline-block h-[16px] w-[100%] max-w-[220px] md:h-[18px]"
+                              />
+                            </div>
+
+                            <div className="flex justify-center mt-6 mb-[40px]">
+
+                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]" >回転：</span>
+                              <input
+                                type="range"
+                                value={rotation}
+                                min={0}
+                                max={360}
+                                step={0.5}
+                                aria-labelledby="Rotation"
+                                onChange={(e) => {
+                                  setRotation(Number(e.target.value))
+                                }}
+                                className="inline-block h-[16px] w-[100%] max-w-[220px] md:h-[18px]"
+                              />
+                            </div>
+
+                            <div className="flex justify-end">
+                              <p onClick={showCroppedImage} className="inline-block border  hover:cursor-pointer hover:opacity-60 font-semibold text-white text-[14px] w-[192px] h-8 rounded  bg-sub-green text-center leading-[32px] md:text-[16px]">トリミングを完了</p>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="md:flex justify-between items-start md:w-[100%] md:max-w-[380px] ">
+                      {/* プレビュー */}
+                      <div className="mb-[64px] md:mb-0">
+                        {croppedImageUrl && (
+                          <>
+                            <p className="text-[14px] mb-1 md:text-[16px] md:mb-2">プレビュー</p>
+                            <img src={croppedImageUrl} alt="" className="w-[100%] max-w-[160px] md:max-w-[180px]" />
+                          </>
+                        )}
+                      </div>
+
+
+                      <div className="flex justify-center md:mt-[32px]">
+                        {croppedImage && (
+                          <>
+                            <div>
+                              <button type="submit" className="text-white text-[14px] w-[200px] h-8 rounded  bg-sub-green md:w-[150px] md:text-[16px] md:block md:ml-auto">画像を追加する</button>
+                              {errors.title.length !== 0 &&
+                                errors.title.map((message, i) => <p key={i} className="text-red-400 mt-2">{message}</p>)
+                              }
+                              {errors.file.length !== 0 &&
+                                errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                              }
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </>
         )}
-      </AuthCheck>
+      </AuthCheck >
     </>
   );
 }
 
-export default RacketImageRegister;
+export default GutImageRegister;

--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -1,0 +1,19 @@
+import AuthCheck from "@/components/AuthCheck";
+import { AuthContext } from "@/context/AuthContext";
+import { NextPage } from "next";
+import { useContext } from "react";
+
+const RacketImageRegister: NextPage = () => {
+  const { isAuth, user } = useContext(AuthContext);
+  return (
+    <>
+      <AuthCheck>
+        {isAuth && (
+          <h1>ラケット登録ページ</h1>
+        )}
+      </AuthCheck>
+    </>
+  );
+}
+
+export default RacketImageRegister;


### PR DESCRIPTION
やったこと：
- racket_imageページへのリンクをheaderに作成
このリンクは開発時でページへ遷移しやすいようにするために作成したもので後で変更の可能性あり

- gut_image登録ページを参考にracket_image登録ページを作成
    実装機能としては
    - react-easy-cropによる画像トリミング機能
    - トリミング後の画像をurl化したものをプレビューとして表示
    - プレビュー確認後、file化されたトリミング後の画像をサーバーへ送信して登録

以上を実装しました

レビューおねがします。