### PR TITLE
modify: userで認証時だけ表示させていたgut関連ページをadminでも閲覧可能に変更

### DIFF
--- a/src/components/AuthCheck.tsx
+++ b/src/components/AuthCheck.tsx
@@ -9,10 +9,10 @@ type AuthProps = {
 const AuthCheck: React.FC<AuthProps> = ({ children }) => {
   const router = useRouter();
 
-  const { isAuth } = useContext(AuthContext);
+  const { isAuth, isAuthAdmin } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!isAuth) {
+    if (!isAuth && !isAuthAdmin) {
       router.push('/users/login');
     }
   }, [])

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -15,7 +15,7 @@ import PrimaryHeading from "@/components/PrimaryHeading";
 const GutImageRegister: NextPage = () => {
   const router = useRouter();
 
-  const { isAuth, user } = useContext(AuthContext);
+  const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
 
   const [title, setTitle] = useState<string>('');
 
@@ -111,7 +111,7 @@ const GutImageRegister: NextPage = () => {
   return (
     <>
       <AuthCheck>
-        {isAuth && (
+        {isAuth || isAuthAdmin && (
           <>
             <div className="container mx-auto mb-[48px]">
               <div className="text-center mb-6 md:mb-[48px]">

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -8,17 +8,19 @@ import Link from "next/link";
 import AuthCheck from "@/components/AuthCheck";
 import TextUnderBar from "@/components/TextUnderBar";
 import PrimaryHeading from "@/components/PrimaryHeading";
+import { Adamina } from "next/font/google";
 
 const GutList = () => {
   const router = useRouter();
-  const { isAuth, user, setUser, setIsAuth } = useContext(AuthContext);
+  const { isAuth, user, setUser, setIsAuth, admin, isAuthAdmin } = useContext(AuthContext);
 
   const [guts, setGuts] = useState<Gut[]>();
+  console.log(guts);
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
   useEffect(() => {
-    if (user.id) {
+    if (user.id || admin.id) {
       const getAllGuts = async () => {
         await axios.get('api/guts').then(res => {
           setGuts(res.data);
@@ -34,7 +36,7 @@ const GutList = () => {
   return (
     <>
       <AuthCheck>
-        {isAuth && (
+        {(isAuth || isAuthAdmin) && (
           <div className="container mx-auto">
             <div className="text-center mb-6">
               <PrimaryHeading text="Strings" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />


### PR DESCRIPTION
**_issue_**: #31 

**_現状：_**
ストリング一覧ページ、ストリング画像提供ページがuserでログインしている時だけ表示されるようになっており、adminでログインしている場合はリダイレクトされてしまう

**_再現手順：_**
- adminでログインする
- adminのdashboardとgut登録ページには遷移することができる
- ストリング一覧ページ、ストリング画像提供ページに遷移しようとする
- userログイン画面にリダイレクトされてしまう

**_やったこと：_**
- AuthCheckコンポーネントでの認証チェックをuserに加えてadminでの認証チェックを追加
- gut一覧ページでuser認証確認のisAuthに加えてisAdminAuthをAuthContextからimportして表示ロジックに追加
- gut_image提供ページでuser認証確認のisAuthに加えてisAdminAuthをAuthContextからimportして表示ロジックに追加

レビューお願いします