### PR TITLE
modify:adminログイン中にgut詳細画面に遷移しようとするとredirectされてしまうことの修正

### DIFF
--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -20,17 +20,17 @@ const Gut = () => {
 
   const otherGutsCount = 5;
 
-  const { isAuth, user } = useContext(AuthContext);
+  const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
   useEffect(() => {
-    if (user.id) {
       const getGut = async () => {
         await axios.get(`/api/guts/${id}`).then(res => {
           setGut(res.data);
         })
       }
+      
       const getOtherGuts = async () => {
         await axios.get(`/api/guts/${id}/others`, {
           params: { count: otherGutsCount }
@@ -41,15 +41,12 @@ const Gut = () => {
 
       getGut();
       getOtherGuts();
-    } else {
-      router.push('/users/login');
-    }
   }, [id])
 
   return (
     <>
       <AuthCheck>
-        {isAuth && (
+        {(isAuth || isAuthAdmin) && (
           <>
             <div className="container md:mx-auto">
               <div className="text-center mb-6 md:mb-[48px]">


### PR DESCRIPTION
issue: #35 

現状：
adminログイン中にgut詳細画面に遷移しようとするとuserログイン画面にredirectされてしまう

やったこと：
- gut詳細画面のuseEffectでuser.idで分岐していた部分を削除し認証チェックはAuthCheckコンポーネントに任せた
- isAuth, isAuthAdminの条件式に( )をつけて条件の区別をはっきりさせるようにした

レビューお願いします