### PR TITLE
add: gut_editページの実装

### DIFF
--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -27,7 +27,6 @@ const GutEdit: NextPage = () => {
   const id = router.query.id;
 
   const [currentGut, setCurrentGut] = useState<Gut>();
-  // console.log('currentGut', currentGut);
 
   //gut登録用のデータstate
   const [inputNameJa, setInputNameJa] = useState<string>('');
@@ -44,13 +43,6 @@ const GutEdit: NextPage = () => {
   const [makers, setMakers] = useState<Maker[]>();
 
   const [selectedGutImage, setSelectedGutImage] = useState<GutImage>();
-
-  // console.log('selectedGutImage', selectedGutImage)
-  // console.log('inputNameJa', inputNameJa)
-  // console.log('inputNameEn', inputNameEn)
-  // console.log('gutMakerId', gutMakerId)
-  // console.log('needPostingImage', needPostingImage)
-  // console.log('gutImageId', gutImageId)
 
   //検索関連のstate
   const [inputSearchWord, setInputSearchWord] = useState<string>('');
@@ -159,10 +151,11 @@ const GutEdit: NextPage = () => {
   //gut登録処理関連
   const csrf = async () => await axios.get('/sanctum/csrf-cookie');
 
-  const registerGut = async (e: React.FormEvent<HTMLFormElement>) => {
+  const updateGut = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const registerData = {
+    const udpatedData = {
+      _method: 'PUT',
       name_ja: inputNameJa,
       name_en: inputNameEn,
       maker_id: gutMakerId,
@@ -172,20 +165,20 @@ const GutEdit: NextPage = () => {
 
     await csrf();
 
-    await axios.post('api/guts', registerData, {
+    await axios.post(`api/guts/${currentGut?.id}`, udpatedData, {
       headers: {
         'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
       }
     }).then(res => {
-      console.log('ストリングを新規登録しました。');
+      console.log('ストリング情報を更新しました。');
 
-      router.push('/guts');
+      router.push(`/guts/${currentGut?.id}`);
     }).catch((e) => {
       const newErrors = { ...initialErrorVals, ...e.response.data.errors };
 
       setErrors(newErrors);
 
-      console.log('ストリングの登録に失敗しました');
+      console.log('ストリング情報の更新に失敗しました');
     })
   }
 
@@ -202,7 +195,7 @@ const GutEdit: NextPage = () => {
               </div>
 
               <div className="w-[100%] max-w-[320px] md:max-w-[380px] mx-auto flex flex-col md:justify-center">
-                <form action="" onSubmit={(e) => registerGut(e)}>
+                <form action="" onSubmit={(e) => updateGut(e)}>
                   <div className="mb-6">
                     <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング名(カナ)</label>
                     <input type="text" name="name_ja" onChange={(e) => setInputNameJa(e.target.value)} defaultValue={currentGut?.name_ja} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
@@ -234,7 +227,7 @@ const GutEdit: NextPage = () => {
 
                   <div className="mb-6">
                     <label htmlFor="need_posting_image" className="text-[14px] mr-1 md:text-[16px]">画像提供受付</label>
-                    <input type="checkbox" name="need_posting_image" id="need_posting_image" defaultChecked={needPostingImage} onChange={(e) => setNeedPostingImage(prev => !prev)} className="align-middle"/>
+                    <input type="checkbox" name="need_posting_image" id="need_posting_image" checked={needPostingImage} onChange={(e) => setNeedPostingImage(e.target.checked)}  className="align-middle"/>
                   </div>
 
                   {/* 画像選択 */}

--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from "next";
+
+const GutEdit: NextPage = () => {
+  return (
+    <>
+      <h1>ストリング情報更新ページ</h1>
+    </>
+  );
+}
+
+export default GutEdit;

--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -1,14 +1,15 @@
+import type { NextPage } from "next";
 import type { Maker } from "@/pages/users/[id]/profile";
 import type { Gut } from "@/pages/reviews";
 
-import AuthAdminCheck from "@/components/AuthAdminCheck";
-import PrimaryHeading from "@/components/PrimaryHeading";
-import { AuthContext } from "@/context/AuthContext";
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
-import type { NextPage } from "next";
-import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthAdminCheck from "@/components/AuthAdminCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
 import { IoClose } from "react-icons/io5";
 
 export type GutImage = {
@@ -31,7 +32,6 @@ const GutEdit: NextPage = () => {
   //gut登録用のデータstate
   const [inputNameJa, setInputNameJa] = useState<string>('');
   
-
   const [inputNameEn, setInputNameEn] = useState<string>('');
 
   const [gutMakerId, setGutMakerId] = useState<number>();

--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -1,11 +1,299 @@
+import type { Maker } from "../users/[id]/profile";
+
+import AuthAdminCheck from "@/components/AuthAdminCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
+import { AuthContext } from "@/context/AuthContext";
+import axios from "@/lib/axios";
+import Cookies from "js-cookie";
 import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import React, { useContext, useEffect, useState } from "react";
+import { IoClose } from "react-icons/io5";
+
+export type GutImage = {
+  id: number,
+  file_path: string,
+  title: string,
+  created_at: string,
+  updated_at: string,
+  maker_id: number,
+  maker: Maker
+}
 
 const GutEdit: NextPage = () => {
+  const router = useRouter();
+
+  //gut登録用のデータstate
+  const [inputNameJa, setInputNameJa] = useState<string>('');
+
+  const [inputNameEn, setInputNameEn] = useState<string>('');
+
+  const [gutMakerId, setGutMakerId] = useState<number | null>(null);
+
+  const [needPostingImage, setNeedPostingImage] = useState<boolean>(true);
+
+  const [gutImageId, setGutImageId] = useState<number>();
+
+  const [makers, setMakers] = useState<Maker[]>();
+
+  const [selectedGutImage, setSelectedGutImage] = useState<GutImage>();
+
+``
+  //検索関連のstate
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+
+  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+
+  const [searchedGutImages, setSearchedGutImages] = useState<GutImage[]>();
+
+  //モーダルの開閉に関するstate
+  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const { admin, isAuthAdmin, } = useContext(AuthContext);
+
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
+
+  useEffect(() => {
+    const getGutList = async () => {
+      await axios.get('api/makers').then(res => {
+        setMakers(res.data);
+      })
+    }
+
+    getGutList();
+  }, [])
+
+  const onChangeMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setGutMakerId(null);
+      return
+    };
+
+    setGutMakerId(Number(e.target.value));
+  }
+
+  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setInputSearchMaker(null);
+      return
+    };
+
+    setInputSearchMaker(Number(e.target.value));
+  }
+
+  //モーダルの開閉
+  const closeModal = () => {
+    setModalVisibilityClassName('opacity-0 scale-0')
+  }
+
+  const openModal = () => {
+    setModalVisibilityClassName('opacity-100 scale-100')
+  }
+
+  //エラーメッセージ関連
+  type Errors = {
+    name_ja: string[],
+    name_en: string[],
+    maker_id: string[],
+    image_id: string[],
+  }
+
+  const initialErrorVals = { name_ja: [], name_en: [], maker_id: [], image_id: [] };
+
+  const [errors, setErrors] = useState<Errors>(initialErrorVals);
+
+  //gutImage検索
+  const searchGutImages = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await axios.get('api/gut_images/search', {
+        params: {
+          several_words: inputSearchWord,
+          maker: inputSearchMaker
+        }
+      }).then((res) => {
+        setSearchedGutImages(res.data);
+      })
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+
+  const selectImage = (gutImage: GutImage) => {
+    setSelectedGutImage(gutImage);
+    setGutImageId(gutImage.id);
+    closeModal();
+  }
+
+  //gut登録処理関連
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const registerGut = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const registerData = {
+      name_ja: inputNameJa,
+      name_en: inputNameEn,
+      maker_id: gutMakerId,
+      image_id: gutImageId,
+      need_posting_image: needPostingImage,
+    }
+
+    await csrf();
+
+    await axios.post('api/guts', registerData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+      }
+    }).then(res => {
+      console.log('ストリングを新規登録しました。');
+
+      router.push('/guts');
+    }).catch((e) => {
+      const newErrors = { ...initialErrorVals, ...e.response.data.errors };
+
+      setErrors(newErrors);
+
+      console.log('ストリングの登録に失敗しました');
+    })
+  }
+
   return (
     <>
-      <h1>ストリング情報更新ページ</h1>
+      <AuthAdminCheck>
+        {isAuthAdmin && (
+          <>
+
+            <div className="container mx-auto mb-8 w-screen pt-[24px] overflow-y-auto">
+
+              <div className="text-center mb-6">
+                <PrimaryHeading text="ストリング登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
+
+              <div className="w-[100%] max-w-[320px] md:max-w-[380px] mx-auto flex flex-col md:justify-center">
+                <form action="" onSubmit={(e) => registerGut(e)}>
+                  <div className="mb-6">
+                    <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング名(カナ)</label>
+                    <input type="text" name="name_ja" onChange={(e) => setInputNameJa(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
+                    {errors.name_ja.length !== 0 &&
+                      errors.name_ja.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                  </div>
+
+                  <div className="mb-6">
+                    <label htmlFor="name_en" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング名(アルファベット)</label>
+                    <input type="text" name="name_en" onChange={(e) => setInputNameEn(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green" />
+                    {errors.name_en.length !== 0 &&
+                      errors.name_en.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                  </div>
+
+                  <div className=" mb-8">
+                    <label htmlFor="maker" className="block text-[14px] md:text-[16px]">メーカー</label>
+
+                    <select name="maker" id="maker" onChange={(e) => { onChangeMaker(e) }} className=" border border-gray-300 rounded w-80 md:w-[380px] h-10 p-2 focus:outline-sub-green">
+                      <option value="未選択" selected>未選択</option>
+                      {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                    </select>
+
+                    {errors.maker_id.length !== 0 &&
+                      errors.maker_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                  </div>
+
+                  <div className="mb-6">
+                    <label htmlFor="need_posting_image" className="text-[14px] mr-1 md:text-[16px]">画像提供受付</label>
+                    <input type="checkbox" name="need_posting_image" id="need_posting_image" defaultChecked={needPostingImage} onChange={(e) => setNeedPostingImage(prev => !prev)} className="align-middle"/>
+                  </div>
+
+                  {/* 画像選択 */}
+                  <div className="mb-[64px] md:w-[100%] md:max-w-[380px]">
+                    <input type="hidden" name="image_id" />
+
+                    <div className="md:w-[100%] md:max-w-[380px]">
+                      <p className="mb-2 text-[14px] md:text-[16px]">選択中：{selectedGutImage ? selectedGutImage.title : 'デフォルト'}</p>
+                      <div className="flex justify-between md:w-[100%] md:max-w-[380px]">
+                        <div className="self-end">
+                          <button type="button" onClick={openModal} className="text-white font-bold text-[14px] w-[80px] h-6 rounded  bg-sub-green">変更</button>
+                        </div>
+
+                        <div className="w-[100%] max-w-[200px] h-[120px] flex justify-center md:h-[160px] md:max-w-[] md:justify-end">
+                          {selectedGutImage
+                            ? <img src={`${baseImagePath}${selectedGutImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />
+                            : <img src={`${baseImagePath}images/guts/default_gut.jpg`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />
+                          }
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex justify-center">
+                    <button type="submit" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">登録</button>
+                  </div>
+                </form>
+              </div>
+
+              {/* 検索モーダル */}
+              <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                  <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                    <IoClose size={48} />
+                  </div>
+
+                  <form action="" onSubmit={searchGutImages} className="mb-[24px] md:flex md:mb-[40px]">
+                    <div className="mb-6 md:mb-0 md:mr-[16px]">
+                      <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">画像 検索ワード</label>
+                      <input type="text" name="name_ja" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                    </div>
+
+                    <div className="mb-8 md:mb-0 md:mr-[24px]">
+                      <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                      <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                        <option value="未選択" selected>未選択</option>
+                        {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                      </select>
+                    </div>
+
+                    <div className="flex justify-end md:justify-start">
+                      <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                    </div>
+                  </form>
+
+                  {/* 検索結果表示欄 */}
+                  <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                    <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                    <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[640px] md:mx-auto md:justify-start">
+                      {searchedGutImages?.map(gutImage => (
+                        <>
+                          {/* ガット画像情報カード */}
+                          <div onClick={() => selectImage(gutImage)} className="bg-white p-2 rounded-lg w-[100%] max-w-[136px] hover:opacity-80 mb-6 hover:cursor-pointer md:[&:not(:last-child)]:mr-[24px]">
+                            <div className="w-[120px] mb-2">
+                              {gutImage.file_path && <img src={`${baseImagePath}${gutImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />}
+                            </div>
+
+                            <p className="text-[14px] mb-1 md:text-[16px]">{gutImage.maker.name_ja}</p>
+
+                            <p className="text-[14px] md:text-[16px]">{gutImage.title}</p>
+                          </div>
+                        </>
+                      ))}
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </AuthAdminCheck>
     </>
   );
 }
 
 export default GutEdit;
+

--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -95,6 +95,14 @@ const Gut = () => {
                     </table>
                   </div>
                 </div>
+                
+                  {isAuthAdmin && (
+                    <div className="flex justify-end">
+                      <Link href={`/guts/${gut?.id}/edit`}>
+                        <button type="button" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">更新</button>
+                      </Link>
+                    </div>
+                  )}
               </div>
 
               {/* otherガットセクション */}

--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -97,7 +97,7 @@ const Gut = () => {
                 </div>
                 
                   {isAuthAdmin && (
-                    <div className="flex justify-end">
+                    <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-6 md:max-w-[720px] md:justify-end">
                       <Link href={`/guts/${gut?.id}/edit`}>
                         <button type="button" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">更新</button>
                       </Link>


### PR DESCRIPTION
背景：
gut情報は初期登録時は画像が用意できていない場合や登録時に誤情報を登録している可能性があるので、編集画面を実装する

やったこと：
- gut登録画面のコードを参考に一度gut_editページのファイルにコピー（編集などはまだ）
- inputタグへのgut詳細情報の初期値表示などレイアウト面の実装（更新機能はまだ）
- gut情報編集機能の実装
- gut_edit画面へのリンクをgut詳細ページにadminログイン時のみ表示されるように実装

レビューお願いします。
