### PR TITLE
add: my_equipment（マイ装備）登録ページのpcサイズレイアウトの作成

### DIFF
--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -288,17 +288,20 @@ const MyEquipmentRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
-            <div className="container mx-auto">
+            <div className="container mx-auto mt-[24px] md:mt-[48px]">
               <div className="text-center mb-6 md:mb-[48px]">
                 <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
-              <div className="w-[100%] max-w-[320px] mx-auto">
+              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
 
-                <form action="" onSubmit={registerGut}>
+                <form
+                  onSubmit={registerGut}
+                  className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:justify-between"
+                >
 
                   {/* //section-one */}
-                  <div>
+                  <div className="md:w-[100%] md:max-w-[360px]">
                     {/* ストリング関連 */}
                     <div>
                       <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
@@ -307,10 +310,16 @@ const MyEquipmentRegister: NextPage = () => {
                       </div>
 
                       {/* 張り方選択 */}
-                      <div className=" mb-8">
+                      <div className="w-[100%] max-w-[320px] mb-8 md:max-w-[360px]">
                         <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
 
-                        <select name="stringing_way" id="stringing_way" value={stringingWay} onChange={onChangeInputStringingWay} className="border border-gray-300 rounded w-[160px] md:w-[380px] h-10 p-2 focus:outline-sub-green">
+                        <select
+                          name="stringing_way"
+                          id="stringing_way"
+                          value={stringingWay}
+                          onChange={onChangeInputStringingWay}
+                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
+                        >
                           <option value="single" >単張り</option>
                           <option value="hybrid" >ハイブリッド</option>
                         </select>
@@ -325,9 +334,9 @@ const MyEquipmentRegister: NextPage = () => {
                         <input type="hidden" name="main_gut_id" value={mainGut ? mainGut.id : undefined} />
                         <input type="hidden" name="cross_gut_id" value={crossGut ? crossGut.id : undefined} />
 
-                        <p className="text-[14px] h-[16px] mb-[8px] leading-[16px]">使用ストリング</p>
+                        <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ストリング</p>
 
-                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">メイン</p>}
+                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">メイン</p>}
                         <div className="mb-6">
 
                           <div className="flex md:w-[100%] md:max-w-[360px]">
@@ -339,15 +348,15 @@ const MyEquipmentRegister: NextPage = () => {
                             </div>
 
                             <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
-                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
 
-                              <div className="border rounded py-[8px] mb-[16px]">
-                                <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{mainGut ? mainGut.maker.name_en : ''}</p>
-                                <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
+                              <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{mainGut ? mainGut.maker.name_en : ''}</p>
+                                <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
                               </div>
 
                               <div className="flex justify-end">
-                                <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green">変更</button>
+                                <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">変更</button>
                               </div>
                             </div>
                           </div>
@@ -362,7 +371,7 @@ const MyEquipmentRegister: NextPage = () => {
                           <>
                             <div className=" mb-6">
 
-                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">クロス</p>
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">クロス</p>
 
                               <div className="flex md:w-[100%] md:max-w-[360px]">
                                 <div className="w-[120px] mr-6">
@@ -373,15 +382,15 @@ const MyEquipmentRegister: NextPage = () => {
                                 </div>
 
                                 <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
-                                  <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
+                                  <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
 
-                                  <div className="border rounded py-[8px] mb-[16px]">
-                                    <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{crossGut ? crossGut.maker.name_ja : ''}</p>
-                                    <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
+                                  <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                    <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{crossGut ? crossGut.maker.name_ja : ''}</p>
+                                    <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
                                   </div>
 
                                   <div className="flex justify-end">
-                                    <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green">変更</button>
+                                    <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green  md:text-[16px]">変更</button>
                                   </div>
                                 </div>
                               </div>
@@ -397,7 +406,7 @@ const MyEquipmentRegister: NextPage = () => {
 
                       {/* gut太さ選択 */}
                       <div className="mb-[24px]">
-                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">太さ（メイン / クロス）</p>
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">太さ（メイン / クロス）</p>
                         <div>
                           <input
                             type="number"
@@ -409,8 +418,8 @@ const MyEquipmentRegister: NextPage = () => {
                             onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
-                          <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px]">mm</span>
-                          <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px]">/</span>
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                          <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
                           <input
                             type="number"
                             name="cross_gut_guage"
@@ -421,7 +430,7 @@ const MyEquipmentRegister: NextPage = () => {
                             onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
-                          <span className="inline-block text-[14px] h-[16px] leading-[16px]">mm</span>
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">mm</span>
                         </div>
                         {errors.main_gut_guage.length !== 0 &&
                           errors.main_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
@@ -433,7 +442,7 @@ const MyEquipmentRegister: NextPage = () => {
 
                       {/* gutテンション選択 */}
                       <div className="mb-6">
-                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">テンション（メイン / クロス）</p>
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">テンション（メイン / クロス）</p>
                         <div>
                           <input
                             type="number"
@@ -445,7 +454,7 @@ const MyEquipmentRegister: NextPage = () => {
                             onChange={(e) => setInputMainGutTension(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
-                          <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px]">/</span>
+                          <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
                           <input
                             type="number"
                             name="cross_gut_guage"
@@ -456,7 +465,7 @@ const MyEquipmentRegister: NextPage = () => {
                             onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
-                          <span className="inline-block text-[14px] h-[16px] leading-[16px]">ポンド</span>
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">ポンド</span>
                         </div>
                         {errors.main_gut_tension.length !== 0 &&
                           errors.main_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
@@ -469,7 +478,7 @@ const MyEquipmentRegister: NextPage = () => {
                       {/* gutを新調日 */}
                       <div className=" mb-6">
                         <div className="flex flex-col">
-                          <label htmlFor="new_gut_date" className="mb-1">張った日</label>
+                          <label htmlFor="new_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張った日</label>
                           <input
                             type="date"
                             name="new_gut_date"
@@ -488,7 +497,7 @@ const MyEquipmentRegister: NextPage = () => {
                       {/* gut交換日 */}
                       <div className="mb-[40px]">
                         <div className="flex flex-col">
-                          <label htmlFor="change_gut_date" className="mb-1">張り替え・ストリングが切れた日</label>
+                          <label htmlFor="change_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張り替え・ストリングが切れた日</label>
                           <input
                             type="date"
                             name="change_gut_date"
@@ -506,7 +515,7 @@ const MyEquipmentRegister: NextPage = () => {
                   </div>
 
                   {/* section-two */}
-                  <div>
+                  <div className="md:w-[100%] md:max-w-[360px]">
                     {/* ラケット関連 */}
                     <div className="mb-[40px]">
                       <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
@@ -514,7 +523,7 @@ const MyEquipmentRegister: NextPage = () => {
                         <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
                       </div>
 
-                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px]">使用ラケット</p>
+                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ラケット</p>
 
                       <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
@@ -525,15 +534,15 @@ const MyEquipmentRegister: NextPage = () => {
                         </div>
 
                         <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
-                          <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
+                          <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
 
                           <div className="border rounded py-[8px] mb-[16px] mb-auto">
-                            <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{racket ? racket.maker.name_en : ''}</p>
-                            <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{racket ? racket.name_ja : '未選択'}</p>
+                            <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[2px]">{racket ? racket.maker.name_en : ''}</p>
+                            <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{racket ? racket.name_ja : '未選択'}</p>
                           </div>
 
                           <div className="flex justify-end">
-                            <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green">ラケットを選択</button>
+                            <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">ラケットを選択</button>
                           </div>
                         </div>
                       </div>
@@ -543,17 +552,25 @@ const MyEquipmentRegister: NextPage = () => {
                       }
                     </div>
 
-                    <div className="mb-[48px]">
+                    <div className="mb-[48px] md:flex md:flex-col md:mb-[64px]">
                       <label htmlFor="comment">コメント</label>
-                      <textarea name="comment" id="comment" onChange={(e) => setComment(e.target.value)} className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green" />
+                      <textarea
+                        name="comment"
+                        id="comment"
+                        onChange={(e) => setComment(e.target.value)}
+                        className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
+                      />
 
                       {errors.comment.length !== 0 &&
                         errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       }
                     </div>
 
-                    <div className="flex justify-center">
-                      <button type="submit" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">追加する</button>
+                    <div className="flex justify-center md:justify-end">
+                      <button
+                        type="submit"
+                        className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
+                      >追加する</button>
                     </div>
                   </div>
 
@@ -589,7 +606,7 @@ const MyEquipmentRegister: NextPage = () => {
                     {/* 検索結果表示欄 */}
                     <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
                       <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[640px] md:mx-auto md:justify-start">
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
                         {/* ガット */}
                         {searchedGuts && searchedGuts.map(gut => (
                           <>
@@ -646,7 +663,7 @@ const MyEquipmentRegister: NextPage = () => {
                     {/* 検索結果表示欄 */}
                     <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
                       <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[640px] md:mx-auto md:justify-start">
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
                         {/* ラケット */}
                         {searchedRackets && searchedRackets.map(racket => (
                           <>

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -296,259 +296,267 @@ const MyEquipmentRegister: NextPage = () => {
               <div className="w-[100%] max-w-[320px] mx-auto">
 
                 <form action="" onSubmit={registerGut}>
-                  {/* ストリング関連 */}
+
+                  {/* //section-one */}
                   <div>
-                    <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
-                      <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
-                      <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
-                    </div>
-
-                    {/* 張り方選択 */}
-                    <div className=" mb-8">
-                      <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
-
-                      <select name="stringing_way" id="stringing_way" value={stringingWay} onChange={onChangeInputStringingWay} className="border border-gray-300 rounded w-[160px] md:w-[380px] h-10 p-2 focus:outline-sub-green">
-                        <option value="single" >単張り</option>
-                        <option value="hybrid" >ハイブリッド</option>
-                      </select>
-
-                      {errors.stringing_way.length !== 0 &&
-                        errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                    </div>
-
-                    {/* ストリング選択セクション */}
+                    {/* ストリング関連 */}
                     <div>
-                      <input type="hidden" name="main_gut_id" value={mainGut ? mainGut.id : undefined} />
-                      <input type="hidden" name="cross_gut_id" value={crossGut ? crossGut.id : undefined} />
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
 
-                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px]">使用ストリング</p>
+                      {/* 張り方選択 */}
+                      <div className=" mb-8">
+                        <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
 
-                      {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">メイン</p>}
+                        <select name="stringing_way" id="stringing_way" value={stringingWay} onChange={onChangeInputStringingWay} className="border border-gray-300 rounded w-[160px] md:w-[380px] h-10 p-2 focus:outline-sub-green">
+                          <option value="single" >単張り</option>
+                          <option value="hybrid" >ハイブリッド</option>
+                        </select>
+
+                        {errors.stringing_way.length !== 0 &&
+                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* ストリング選択セクション */}
+                      <div>
+                        <input type="hidden" name="main_gut_id" value={mainGut ? mainGut.id : undefined} />
+                        <input type="hidden" name="cross_gut_id" value={crossGut ? crossGut.id : undefined} />
+
+                        <p className="text-[14px] h-[16px] mb-[8px] leading-[16px]">使用ストリング</p>
+
+                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">メイン</p>}
+                        <div className="mb-6">
+
+                          <div className="flex md:w-[100%] md:max-w-[360px]">
+                            <div className="w-[120px] mr-6">
+                              {mainGut && mainGut.gut_image.file_path
+                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                              }
+                            </div>
+
+                            <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
+
+                              <div className="border rounded py-[8px] mb-[16px]">
+                                <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{mainGut ? mainGut.maker.name_en : ''}</p>
+                                <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
+                              </div>
+
+                              <div className="flex justify-end">
+                                <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green">変更</button>
+                              </div>
+                            </div>
+                          </div>
+
+                          {errors.main_gut_id.length !== 0 &&
+                            errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                          }
+                        </div>
+
+                        {/* ハイブリッド張りの時crossGutを表示 */}
+                        {stringingWay === 'hybrid' && (
+                          <>
+                            <div className=" mb-6">
+
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">クロス</p>
+
+                              <div className="flex md:w-[100%] md:max-w-[360px]">
+                                <div className="w-[120px] mr-6">
+                                  {crossGut && crossGut.gut_image.file_path
+                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  }
+                                </div>
+
+                                <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                                  <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
+
+                                  <div className="border rounded py-[8px] mb-[16px]">
+                                    <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{crossGut ? crossGut.maker.name_ja : ''}</p>
+                                    <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
+                                  </div>
+
+                                  <div className="flex justify-end">
+                                    <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green">変更</button>
+                                  </div>
+                                </div>
+                              </div>
+
+                              {errors.cross_gut_id.length !== 0 &&
+                                errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                              }
+                            </div>
+                          </>
+                        )}
+
+                      </div>
+
+                      {/* gut太さ選択 */}
+                      <div className="mb-[24px]">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">太さ（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={0.01}
+                            defaultValue={1.25}
+                            min="1.05"
+                            max="1.50"
+                            onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px]">mm</span>
+                          <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={0.01}
+                            defaultValue={1.25}
+                            min="1.05"
+                            max="1.50"
+                            onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px]">mm</span>
+                        </div>
+                        {errors.main_gut_guage.length !== 0 &&
+                          errors.main_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_guage.length !== 0 &&
+                          errors.cross_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gutテンション選択 */}
                       <div className="mb-6">
-
-                        <div className="flex md:w-[100%] md:max-w-[360px]">
-                          <div className="w-[120px] mr-6">
-                            {mainGut && mainGut.gut_image.file_path
-                              ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                              : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                            }
-                          </div>
-
-                          <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
-                            <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
-
-                            <div className="border rounded py-[8px] mb-[16px]">
-                              <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{mainGut ? mainGut.maker.name_en : ''}</p>
-                              <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
-                            </div>
-
-                            <div className="flex justify-end">
-                              <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green">変更</button>
-                            </div>
-                          </div>
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">テンション（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={1}
+                            defaultValue={50}
+                            min="1"
+                            max="100"
+                            onChange={(e) => setInputMainGutTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={1}
+                            defaultValue={50}
+                            min="1"
+                            max="100"
+                            onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px]">ポンド</span>
                         </div>
-
-                        {errors.main_gut_id.length !== 0 &&
-                          errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        {errors.main_gut_tension.length !== 0 &&
+                          errors.main_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_tension.length !== 0 &&
+                          errors.cross_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                         }
                       </div>
 
-                      {/* ハイブリッド張りの時crossGutを表示 */}
-                      {stringingWay === 'hybrid' && (
-                        <>
-                          <div className=" mb-6">
+                      {/* gutを新調日 */}
+                      <div className=" mb-6">
+                        <div className="flex flex-col">
+                          <label htmlFor="new_gut_date" className="mb-1">張った日</label>
+                          <input
+                            type="date"
+                            name="new_gut_date"
+                            id="new_gut_date"
+                            defaultValue={today}
+                            onChange={onChangeInputNewGutDate}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                        </div>
 
-                            <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">クロス</p>
-
-                            <div className="flex md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {crossGut && crossGut.gut_image.file_path
-                                  ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                  : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
-                                <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
-
-                                <div className="border rounded py-[8px] mb-[16px]">
-                                  <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{crossGut ? crossGut.maker.name_ja : ''}</p>
-                                  <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
-                                </div>
-
-                                <div className="flex justify-end">
-                                  <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green">変更</button>
-                                </div>
-                              </div>
-                            </div>
-
-                            {errors.cross_gut_id.length !== 0 &&
-                              errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                            }
-                          </div>
-                        </>
-                      )}
-
-                    </div>
-
-                    {/* gut太さ選択 */}
-                    <div className="mb-[24px]">
-                      <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">太さ（メイン / クロス）</p>
-                      <div>
-                        <input
-                          type="number"
-                          name="main_gut_guage"
-                          step={0.01}
-                          defaultValue={1.25}
-                          min="1.05"
-                          max="1.50"
-                          onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
-                          className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
-                        />
-                        <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px]">mm</span>
-                        <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px]">/</span>
-                        <input
-                          type="number"
-                          name="cross_gut_guage"
-                          step={0.01}
-                          defaultValue={1.25}
-                          min="1.05"
-                          max="1.50"
-                          onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
-                          className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
-                        />
-                        <span className="inline-block text-[14px] h-[16px] leading-[16px]">mm</span>
-                      </div>
-                      {errors.main_gut_guage.length !== 0 &&
-                        errors.main_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                      {errors.cross_gut_guage.length !== 0 &&
-                        errors.cross_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                    </div>
-
-                    {/* gutテンション選択 */}
-                    <div className="mb-6">
-                      <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">テンション（メイン / クロス）</p>
-                      <div>
-                        <input
-                          type="number"
-                          name="main_gut_guage"
-                          step={1}
-                          defaultValue={50}
-                          min="1"
-                          max="100"
-                          onChange={(e) => setInputMainGutTension(Number(e.target.value))}
-                          className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
-                        />
-                        <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px]">/</span>
-                        <input
-                          type="number"
-                          name="cross_gut_guage"
-                          step={1}
-                          defaultValue={50}
-                          min="1"
-                          max="100"
-                          onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
-                          className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
-                        />
-                        <span className="inline-block text-[14px] h-[16px] leading-[16px]">ポンド</span>
-                      </div>
-                      {errors.main_gut_tension.length !== 0 &&
-                        errors.main_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                      {errors.cross_gut_tension.length !== 0 &&
-                        errors.cross_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                    </div>
-
-                    {/* gutを新調日 */}
-                    <div className=" mb-6">
-                      <div className="flex flex-col">
-                        <label htmlFor="new_gut_date" className="mb-1">張った日</label>
-                        <input
-                          type="date"
-                          name="new_gut_date"
-                          id="new_gut_date"
-                          defaultValue={today}
-                          onChange={onChangeInputNewGutDate}
-                          className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
-                        />
+                        {errors.new_gut_date.length !== 0 &&
+                          errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
                       </div>
 
-                      {errors.new_gut_date.length !== 0 &&
-                        errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                    </div>
+                      {/* gut交換日 */}
+                      <div className="mb-[40px]">
+                        <div className="flex flex-col">
+                          <label htmlFor="change_gut_date" className="mb-1">張り替え・ストリングが切れた日</label>
+                          <input
+                            type="date"
+                            name="change_gut_date"
+                            id="change_gut_date"
+                            onChange={onChangeInputChangeGutDate}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                        </div>
 
-                    {/* gut交換日 */}
+                        {errors.change_gut_date.length !== 0 &&
+                          errors.change_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* section-two */}
+                  <div>
+                    {/* ラケット関連 */}
                     <div className="mb-[40px]">
-                      <div className="flex flex-col">
-                        <label htmlFor="change_gut_date" className="mb-1">張り替え・ストリングが切れた日</label>
-                        <input
-                          type="date"
-                          name="change_gut_date"
-                          id="change_gut_date"
-                          onChange={onChangeInputChangeGutDate}
-                          className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
-                        />
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
                       </div>
 
-                      {errors.change_gut_date.length !== 0 &&
-                        errors.change_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px]">使用ラケット</p>
+
+                      <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {racket && racket.racket_image.file_path
+                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
+                          <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
+
+                          <div className="border rounded py-[8px] mb-[16px] mb-auto">
+                            <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{racket ? racket.maker.name_en : ''}</p>
+                            <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{racket ? racket.name_ja : '未選択'}</p>
+                          </div>
+
+                          <div className="flex justify-end">
+                            <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green">ラケットを選択</button>
+                          </div>
+                        </div>
+                      </div>
+
+                      {errors.racket_id.length !== 0 &&
+                        errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       }
                     </div>
-                  </div>
 
-                  {/* ラケット関連 */}
-                  <div className="mb-[40px]">
-                    <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
-                      <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
-                      <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                    <div className="mb-[48px]">
+                      <label htmlFor="comment">コメント</label>
+                      <textarea name="comment" id="comment" onChange={(e) => setComment(e.target.value)} className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green" />
+
+                      {errors.comment.length !== 0 &&
+                        errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
                     </div>
 
-                    <p className="text-[14px] h-[16px] mb-[8px] leading-[16px]">使用ラケット</p>
-
-                    <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
-                      <div className="w-[120px] mr-6">
-                        {racket && racket.racket_image.file_path
-                          ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                          : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                        }
-                      </div>
-
-                      <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
-                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px]">選択中</p>
-
-                        <div className="border rounded py-[8px] mb-[16px] mb-auto">
-                          <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px]">{racket ? racket.maker.name_en : ''}</p>
-                          <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px]">{racket ? racket.name_ja : '未選択'}</p>
-                        </div>
-
-                        <div className="flex justify-end">
-                          <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green">ラケットを選択</button>
-                        </div>
-                      </div>
+                    <div className="flex justify-center">
+                      <button type="submit" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">追加する</button>
                     </div>
-
-                    {errors.racket_id.length !== 0 &&
-                      errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                    }
                   </div>
 
-                  <div className="mb-[48px]">
-                    <label htmlFor="comment">コメント</label>
-                    <textarea name="comment" id="comment" onChange={(e) => setComment(e.target.value)} className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green" />
-
-                    {errors.comment.length !== 0 &&
-                      errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                    }
-                  </div>
-
-                  <div className="flex justify-center">
-                    <button type="submit" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">追加する</button>
-                  </div>
                 </form>
 
                 {/* gut検索モーダル */}


### PR DESCRIPTION
issue: #44 

現状：my_equipment登録ページのpcサイズレイアウトがまだ完全に設定されておらず、一部spサイズのレイアウトのまま表示されている。

再現手順：
- my_equipment登録ページに遷移する
- ウィンドウをpcサイズにする
- レイアウトがspサイズの表示のままの部分が多数ある
- また、検索モーダルの検索結果の表示がspの表示のままで縦並びである

やったこと：
- 全体的なレイアウトの調整（文字サイズ、並び、widthの調整）
- 検索モーダルの検索結果表示のpcサイズレイアウトの追加

備考：
flex boxで横並びにするためにsection-one、section-twoのように二つのdiv要素で区切ったので、その際の行移動をさせる範囲が多かったため、それを一つcommitでまとめてあります。

備考に書いた通り変更行が多くなっているのでcommit単位でレビューいただけると簡単かと思います。

レビューお願いします。