### PR TITLE
add: my_equipment編集ページの作成

### DIFF
--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from "next";
 import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile";
 import type { Gut } from "@/pages/reviews"; 
+import type { MyEquipment } from "@/pages/reviews";
 
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
@@ -17,7 +18,13 @@ import { IoClose } from "react-icons/io5";
 import { getToday } from "@/modules/getToday";
 
 const MyEquipmentEdit: NextPage = () => {
+  
   const router = useRouter();
+  
+  const currentMyEquipmentId = router.query.id;
+
+  const [currentMyEquipment, setCurrentMyEquipment] = useState<MyEquipment>();
+  console.log('currentMyEquipment', currentMyEquipment)
 
   const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
 
@@ -26,13 +33,17 @@ const MyEquipmentEdit: NextPage = () => {
   const [userTennisProfile, setUserTennisProfile] = useState<TennisProfile>();
 
   //my_equipmentの登録に使うstate群
-  const [stringingWay, setStringingWay] = useState<string>('single');
+  const [stringingWay, setStringingWay] = useState<string>('');
+  console.log('stringingWay', stringingWay)
 
   const [mainGut, setMainGut] = useState<Gut>();
+  console.log('mainGut', mainGut)
 
   const [crossGut, setCrossGut] = useState<Gut>();
+  console.log('crossGut', crossGut)
 
   const [racket, setRacket] = useState<Racket>();
+  console.log('racket', racket)
 
   //要素の表示などに使用するstate群
   const [makers, setMakers] = useState<Maker[]>();
@@ -40,19 +51,26 @@ const MyEquipmentEdit: NextPage = () => {
   const [witchSelectingGut, setWitchSelectingGut] = useState<string>('');
 
   // inputに関するstate
-  const [inputMainGutGuage, setInputMainGutGuage] = useState<number>(1.25);
+  const [inputMainGutGuage, setInputMainGutGuage] = useState<number>();
+  console.log('inputMainGutGuage', inputMainGutGuage)
 
-  const [inputCrossGutGuage, setInputCrossGutGuage] = useState<number>(1.25);
+  const [inputCrossGutGuage, setInputCrossGutGuage] = useState<number>();
+  console.log('inputCrossGutGuage', inputCrossGutGuage)
 
-  const [inputMainGutTension, setInputMainGutTension] = useState<number>(50);
+  const [inputMainGutTension, setInputMainGutTension] = useState<number>();
+  console.log('inputMainGutTension', inputMainGutTension)
 
-  const [inputMainCrossTension, setInputMainCrossTension] = useState<number>(50);
+  const [inputMainCrossTension, inputCrossGutTension] = useState<number>();
+  console.log('inputMainCrossTension', inputMainCrossTension)
 
-  const [inputNewGutDate, setInputNewGutDate] = useState<string>(today);
+  const [inputNewGutDate, setInputNewGutDate] = useState<string>();
+  console.log('inputNewGutDate', inputNewGutDate)
 
-  const [inputChangeGutDate, setInputChangeGutDate] = useState<string>();
+  const [inputChangeGutDate, setInputChangeGutDate] = useState<string | null | undefined>();
+  console.log('inputChangeGutDate', inputChangeGutDate)
 
   const [comment, setComment] = useState<string>('');
+  console.log('comment', comment)
 
   //モーダルの開閉に関するstate
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
@@ -81,6 +99,25 @@ const MyEquipmentEdit: NextPage = () => {
       })
     }
 
+    const getCurrentMyEquipment = async () => {
+      await axios.get(`api/my_equipments/${currentMyEquipmentId}`).then(res => {
+        const myEquipment: MyEquipment = res.data;
+        setCurrentMyEquipment(myEquipment);
+        setStringingWay(myEquipment.stringing_way);
+        setMainGut(myEquipment.main_gut);
+        setCrossGut(myEquipment.cross_gut);
+        setRacket(myEquipment.racket);
+        setInputMainGutGuage(myEquipment.main_gut_guage);
+        setInputCrossGutGuage(myEquipment.cross_gut_guage);
+        setInputMainGutTension(myEquipment.main_gut_tension);
+        inputCrossGutTension(myEquipment.cross_gut_tension);
+        setInputNewGutDate(myEquipment.new_gut_date);
+        setInputChangeGutDate(myEquipment.change_gut_date);
+        setComment(myEquipment.comment);
+      })
+    }
+
+    getCurrentMyEquipment();
     getUserTennisProfile();
     getMakerList();
   }, [])
@@ -412,7 +449,7 @@ const MyEquipmentEdit: NextPage = () => {
                             type="number"
                             name="main_gut_guage"
                             step={0.01}
-                            defaultValue={1.25}
+                            defaultValue={inputMainGutGuage?.toFixed(2)}
                             min="1.05"
                             max="1.50"
                             onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
@@ -424,7 +461,7 @@ const MyEquipmentEdit: NextPage = () => {
                             type="number"
                             name="cross_gut_guage"
                             step={0.01}
-                            defaultValue={1.25}
+                            defaultValue={inputCrossGutGuage?.toFixed(2)}
                             min="1.05"
                             max="1.50"
                             onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
@@ -448,7 +485,7 @@ const MyEquipmentEdit: NextPage = () => {
                             type="number"
                             name="main_gut_guage"
                             step={1}
-                            defaultValue={50}
+                            defaultValue={inputMainGutTension}
                             min="1"
                             max="100"
                             onChange={(e) => setInputMainGutTension(Number(e.target.value))}
@@ -459,10 +496,10 @@ const MyEquipmentEdit: NextPage = () => {
                             type="number"
                             name="cross_gut_guage"
                             step={1}
-                            defaultValue={50}
+                            defaultValue={inputMainCrossTension}
                             min="1"
                             max="100"
-                            onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
+                            onChange={(e) => inputCrossGutTension(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
                           <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">ポンド</span>
@@ -483,7 +520,7 @@ const MyEquipmentEdit: NextPage = () => {
                             type="date"
                             name="new_gut_date"
                             id="new_gut_date"
-                            defaultValue={today}
+                            defaultValue={inputNewGutDate}
                             onChange={onChangeInputNewGutDate}
                             className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
@@ -502,6 +539,7 @@ const MyEquipmentEdit: NextPage = () => {
                             type="date"
                             name="change_gut_date"
                             id="change_gut_date"
+                            defaultValue={inputChangeGutDate ? inputChangeGutDate : ''}
                             onChange={onChangeInputChangeGutDate}
                             className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
@@ -557,6 +595,7 @@ const MyEquipmentEdit: NextPage = () => {
                       <textarea
                         name="comment"
                         id="comment"
+                        defaultValue={comment}
                         onChange={(e) => setComment(e.target.value)}
                         className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
                       />

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -1,12 +1,702 @@
-import { NextPage } from "next";
+import type { NextPage } from "next";
+import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile";
+import type { Gut } from "@/pages/reviews"; 
 
+import axios from "@/lib/axios";
+import Cookies from "js-cookie";
+
+import React, { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
+import SubHeading from "@/components/SubHeading";
+import TextUnderBar from "@/components/TextUnderBar";
+import { IoClose } from "react-icons/io5";
+import { getToday } from "@/modules/getToday";
 
 const MyEquipmentEdit: NextPage = () => {
+  const router = useRouter();
+
+  const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
+
+  const today: string = getToday();
+
+  const [userTennisProfile, setUserTennisProfile] = useState<TennisProfile>();
+
+  //my_equipmentの登録に使うstate群
+  const [stringingWay, setStringingWay] = useState<string>('single');
+
+  const [mainGut, setMainGut] = useState<Gut>();
+
+  const [crossGut, setCrossGut] = useState<Gut>();
+
+  const [racket, setRacket] = useState<Racket>();
+
+  //要素の表示などに使用するstate群
+  const [makers, setMakers] = useState<Maker[]>();
+
+  const [witchSelectingGut, setWitchSelectingGut] = useState<string>('');
+
+  // inputに関するstate
+  const [inputMainGutGuage, setInputMainGutGuage] = useState<number>(1.25);
+
+  const [inputCrossGutGuage, setInputCrossGutGuage] = useState<number>(1.25);
+
+  const [inputMainGutTension, setInputMainGutTension] = useState<number>(50);
+
+  const [inputMainCrossTension, setInputMainCrossTension] = useState<number>(50);
+
+  const [inputNewGutDate, setInputNewGutDate] = useState<string>(today);
+
+  const [inputChangeGutDate, setInputChangeGutDate] = useState<string>();
+
+  const [comment, setComment] = useState<string>('');
+
+  //モーダルの開閉に関するstate
+  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  //検索関連のstate
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+
+  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+
+  const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
+
+  const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
+
+  useEffect(() => {
+    const getMakerList = async () => {
+      await axios.get('api/makers').then(res => {
+        setMakers(res.data);
+      })
+    }
+
+    const getUserTennisProfile = async () => {
+      await axios.get(`api/tennis_profiles/${user.id}`).then(res => {
+        setUserTennisProfile(res.data);
+      })
+    }
+
+    getUserTennisProfile();
+    getMakerList();
+  }, [])
+
+  //inputの制御関数群
+  const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setStringingWay(e.target.value);
+    setCrossGut(undefined);
+  }
+
+  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setInputSearchMaker(null);
+      return
+    };
+
+    setInputSearchMaker(Number(e.target.value));
+  }
+
+  const onChangeInputNewGutDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const todayRegex: RegExp = /\d{4}-\d{2}-\d{2}$/;
+
+    if (todayRegex.test(e.target.value)) {
+      setInputNewGutDate(e.target.value);
+    }
+  }
+
+  const onChangeInputChangeGutDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const todayRegex: RegExp = /\d{4}-\d{2}-\d{2}$/;
+
+    if (todayRegex.test(e.target.value)) {
+      setInputChangeGutDate(e.target.value);
+    }
+  }
+
+  //モーダルの開閉
+  const closeModal = () => {
+    setModalVisibilityClassName('opacity-0 scale-0')
+    setWitchSelectingGut('');
+  }
+
+  const openModal = () => {
+    setModalVisibilityClassName('opacity-100 scale-100')
+  }
+
+  //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
+  const openMainGutSearchModal = () => {
+    openModal();
+    setWitchSelectingGut('main');
+  }
+
+  const openCrossGutSearchModal = () => {
+    openModal();
+    setWitchSelectingGut('cross');
+  }
+
+  //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
+  const openRacketSearchModal = () => {
+    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
+  }
+
+  const closeRacketSearchModal = () => {
+    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+  }
+
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
+
+  //gut検索
+  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await axios.get('api/guts/search', {
+        params: {
+          several_words: inputSearchWord,
+          maker: inputSearchMaker
+        }
+      }).then((res) => {
+        setSearchedGuts(res.data);
+      })
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  //racket検索
+  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      await axios.get('api/rackets/search', {
+        params: {
+          several_words: inputSearchWord,
+          maker: inputSearchMaker
+        }
+      }).then((res) => {
+        setSearchedRackets(res.data);
+      })
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  const selectGut = (gut: Gut) => {
+    if (witchSelectingGut === 'main') {
+      setMainGut(gut);
+    } else if (witchSelectingGut === 'cross') {
+      setCrossGut(gut);
+    }
+
+    closeModal();
+  }
+  const selectRacket = (racket: Racket) => {
+    setRacket(racket)
+    closeRacketSearchModal();
+  }
+
+  type Errors = {
+    user_id: string[],
+    user_height: string[],
+    user_age: string[],
+    experience_period: string[],
+    stringing_way: string[],
+    main_gut_id: string[],
+    cross_gut_id: string[],
+    main_gut_guage: string[],
+    cross_gut_guage: string[],
+    main_gut_tension: string[],
+    cross_gut_tension: string[],
+    racket_id: string[],
+    new_gut_date: string[],
+    change_gut_date: string[],
+    comment: string[],
+  }
+
+  const initialErrorVals = {
+    user_id: [],
+    user_height: [],
+    user_age: [],
+    experience_period: [],
+    stringing_way: [],
+    main_gut_id: [],
+    cross_gut_id: [],
+    main_gut_guage: [],
+    cross_gut_guage: [],
+    main_gut_tension: [],
+    cross_gut_tension: [],
+    racket_id: [],
+    new_gut_date: [],
+    change_gut_date: [],
+    comment: [],
+  }
+
+  const [errors, setErrors] = useState<Errors>(initialErrorVals);
+
+  //gut登録処理関連
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const registerGut = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const registerData = {
+      user_id: user.id,
+      user_height: userTennisProfile?.height,
+      user_age: userTennisProfile?.age,
+      experience_period: userTennisProfile?.experience_period,
+      stringing_way: stringingWay,
+      main_gut_id: mainGut?.id,
+      cross_gut_id: stringingWay === 'hybrid' && crossGut ? crossGut.id : mainGut?.id,
+      main_gut_guage: inputMainGutGuage,
+      cross_gut_guage: inputCrossGutGuage,
+      main_gut_tension: inputMainGutTension,
+      cross_gut_tension: inputMainCrossTension,
+      racket_id: racket?.id,
+      new_gut_date: inputNewGutDate,
+      change_gut_date: inputChangeGutDate ? inputChangeGutDate : null,
+      comment: comment,
+    }
+
+    await csrf();
+
+    await axios.post('api/my_equipments', registerData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+      }
+    }).then(res => {
+      console.log('マイ装備を追加しました。');
+
+      router.push('/my_equipments');
+    }).catch((e) => {
+      const newErrors = { ...initialErrorVals, ...e.response.data.errors };
+
+      setErrors(newErrors);
+
+      console.log('マイ装備の追加に失敗しました');
+    })
+  }
+
   return (
     <>
-      <h1>マイ装備編集ページ</h1>
+      <AuthCheck>
+        {(isAuth || isAuthAdmin) && (
+          <>
+            <div className="container mx-auto mt-[24px] md:mt-[48px]">
+              <div className="text-center mb-6 md:mb-[48px]">
+                <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
+
+              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+
+                <form
+                  onSubmit={registerGut}
+                  className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:justify-between"
+                >
+
+                  {/* //section-one */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+                    {/* ストリング関連 */}
+                    <div>
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      {/* 張り方選択 */}
+                      <div className="w-[100%] max-w-[320px] mb-8 md:max-w-[360px]">
+                        <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
+
+                        <select
+                          name="stringing_way"
+                          id="stringing_way"
+                          value={stringingWay}
+                          onChange={onChangeInputStringingWay}
+                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
+                        >
+                          <option value="single" >単張り</option>
+                          <option value="hybrid" >ハイブリッド</option>
+                        </select>
+
+                        {errors.stringing_way.length !== 0 &&
+                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* ストリング選択セクション */}
+                      <div>
+                        <input type="hidden" name="main_gut_id" value={mainGut ? mainGut.id : undefined} />
+                        <input type="hidden" name="cross_gut_id" value={crossGut ? crossGut.id : undefined} />
+
+                        <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ストリング</p>
+
+                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">メイン</p>}
+                        <div className="mb-6">
+
+                          <div className="flex md:w-[100%] md:max-w-[360px]">
+                            <div className="w-[120px] mr-6">
+                              {mainGut && mainGut.gut_image.file_path
+                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                              }
+                            </div>
+
+                            <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                              <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{mainGut ? mainGut.maker.name_en : ''}</p>
+                                <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
+                              </div>
+
+                              <div className="flex justify-end">
+                                <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">変更</button>
+                              </div>
+                            </div>
+                          </div>
+
+                          {errors.main_gut_id.length !== 0 &&
+                            errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                          }
+                        </div>
+
+                        {/* ハイブリッド張りの時crossGutを表示 */}
+                        {stringingWay === 'hybrid' && (
+                          <>
+                            <div className=" mb-6">
+
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">クロス</p>
+
+                              <div className="flex md:w-[100%] md:max-w-[360px]">
+                                <div className="w-[120px] mr-6">
+                                  {crossGut && crossGut.gut_image.file_path
+                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  }
+                                </div>
+
+                                <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                                  <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                                  <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                    <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{crossGut ? crossGut.maker.name_ja : ''}</p>
+                                    <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
+                                  </div>
+
+                                  <div className="flex justify-end">
+                                    <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green  md:text-[16px]">変更</button>
+                                  </div>
+                                </div>
+                              </div>
+
+                              {errors.cross_gut_id.length !== 0 &&
+                                errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                              }
+                            </div>
+                          </>
+                        )}
+
+                      </div>
+
+                      {/* gut太さ選択 */}
+                      <div className="mb-[24px]">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">太さ（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={0.01}
+                            defaultValue={1.25}
+                            min="1.05"
+                            max="1.50"
+                            onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                          <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={0.01}
+                            defaultValue={1.25}
+                            min="1.05"
+                            max="1.50"
+                            onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                        </div>
+                        {errors.main_gut_guage.length !== 0 &&
+                          errors.main_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_guage.length !== 0 &&
+                          errors.cross_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gutテンション選択 */}
+                      <div className="mb-6">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">テンション（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={1}
+                            defaultValue={50}
+                            min="1"
+                            max="100"
+                            onChange={(e) => setInputMainGutTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={1}
+                            defaultValue={50}
+                            min="1"
+                            max="100"
+                            onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">ポンド</span>
+                        </div>
+                        {errors.main_gut_tension.length !== 0 &&
+                          errors.main_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_tension.length !== 0 &&
+                          errors.cross_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gutを新調日 */}
+                      <div className=" mb-6">
+                        <div className="flex flex-col">
+                          <label htmlFor="new_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張った日</label>
+                          <input
+                            type="date"
+                            name="new_gut_date"
+                            id="new_gut_date"
+                            defaultValue={today}
+                            onChange={onChangeInputNewGutDate}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                        </div>
+
+                        {errors.new_gut_date.length !== 0 &&
+                          errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gut交換日 */}
+                      <div className="mb-[40px]">
+                        <div className="flex flex-col">
+                          <label htmlFor="change_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張り替え・ストリングが切れた日</label>
+                          <input
+                            type="date"
+                            name="change_gut_date"
+                            id="change_gut_date"
+                            onChange={onChangeInputChangeGutDate}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                        </div>
+
+                        {errors.change_gut_date.length !== 0 &&
+                          errors.change_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* section-two */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+                    {/* ラケット関連 */}
+                    <div className="mb-[40px]">
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ラケット</p>
+
+                      <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {racket && racket.racket_image.file_path
+                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
+                          <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                          <div className="border rounded py-[8px] mb-[16px] mb-auto">
+                            <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[2px]">{racket ? racket.maker.name_en : ''}</p>
+                            <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{racket ? racket.name_ja : '未選択'}</p>
+                          </div>
+
+                          <div className="flex justify-end">
+                            <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">ラケットを選択</button>
+                          </div>
+                        </div>
+                      </div>
+
+                      {errors.racket_id.length !== 0 &&
+                        errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+
+                    <div className="mb-[48px] md:flex md:flex-col md:mb-[64px]">
+                      <label htmlFor="comment">コメント</label>
+                      <textarea
+                        name="comment"
+                        id="comment"
+                        onChange={(e) => setComment(e.target.value)}
+                        className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
+                      />
+
+                      {errors.comment.length !== 0 &&
+                        errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+
+                    <div className="flex justify-center md:justify-end">
+                      <button
+                        type="submit"
+                        className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
+                      >追加する</button>
+                    </div>
+                  </div>
+
+                </form>
+
+                {/* gut検索モーダル */}
+                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                        {/* ガット */}
+                        {searchedGuts && searchedGuts.map(gut => (
+                          <>
+                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                              <div className="w-[120px] mr-6">
+                                {gut.gut_image.file_path
+                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                }
+                              </div>
+
+                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
+                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
+                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                              </div>
+                            </div>
+                          </>
+                        ))}
+
+                      </div>
+                    </div>
+
+                  </div>
+                </div>
+
+                {/* racket検索モーダル */}
+                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                        {/* ラケット */}
+                        {searchedRackets && searchedRackets.map(racket => (
+                          <>
+                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                              <div className="w-[120px] mr-6">
+                                {racket.racket_image.file_path
+                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                                }
+                              </div>
+
+                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
+                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
+                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                              </div>
+                            </div>
+                          </>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+
+        )}
+      </AuthCheck>
+
     </>
   );
 }
 
 export default MyEquipmentEdit;
+

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -280,14 +280,14 @@ const MyEquipmentEdit: NextPage = () => {
   //gut登録処理関連
   const csrf = async () => await axios.get('/sanctum/csrf-cookie');
 
-  const registerGut = async (e: React.FormEvent<HTMLFormElement>) => {
+  const updateMyEquipment = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const registerData = {
-      user_id: user.id,
-      user_height: userTennisProfile?.height,
-      user_age: userTennisProfile?.age,
-      experience_period: userTennisProfile?.experience_period,
+    const updatedData = {
+      _method: 'PUT',
+      user_height: currentMyEquipment?.user_height,
+      user_age: currentMyEquipment?.user_age,
+      experience_period: currentMyEquipment?.experience_period,
       stringing_way: stringingWay,
       main_gut_id: mainGut?.id,
       cross_gut_id: stringingWay === 'hybrid' && crossGut ? crossGut.id : mainGut?.id,
@@ -303,20 +303,20 @@ const MyEquipmentEdit: NextPage = () => {
 
     await csrf();
 
-    await axios.post('api/my_equipments', registerData, {
+    await axios.post(`api/my_equipments/${currentMyEquipmentId}`, updatedData, {
       headers: {
         'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
       }
     }).then(res => {
-      console.log('マイ装備を追加しました。');
+      console.log('マイ装備を更新しました。');
 
-      router.push('/my_equipments');
+      router.push(`/my_equipments/${currentMyEquipmentId}/my_equipment`);
     }).catch((e) => {
       const newErrors = { ...initialErrorVals, ...e.response.data.errors };
 
       setErrors(newErrors);
 
-      console.log('マイ装備の追加に失敗しました');
+      console.log('マイ装備の更新に失敗しました');
     })
   }
 
@@ -333,7 +333,7 @@ const MyEquipmentEdit: NextPage = () => {
               <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
 
                 <form
-                  onSubmit={registerGut}
+                  onSubmit={updateMyEquipment}
                   className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:justify-between"
                 >
 
@@ -609,7 +609,7 @@ const MyEquipmentEdit: NextPage = () => {
                       <button
                         type="submit"
                         className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
-                      >追加する</button>
+                      >更新する</button>
                     </div>
                   </div>
 

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile";
-import type { Gut } from "@/pages/reviews"; 
+import type { Gut } from "@/pages/reviews";
 import type { MyEquipment } from "@/pages/reviews";
 
 import axios from "@/lib/axios";
@@ -18,32 +18,24 @@ import { IoClose } from "react-icons/io5";
 import { getToday } from "@/modules/getToday";
 
 const MyEquipmentEdit: NextPage = () => {
-  
-  const router = useRouter();
-  
-  const currentMyEquipmentId = router.query.id;
 
-  const [currentMyEquipment, setCurrentMyEquipment] = useState<MyEquipment>();
-  console.log('currentMyEquipment', currentMyEquipment)
+  const router = useRouter();
 
   const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
 
-  const today: string = getToday();
+  const currentMyEquipmentId = router.query.id;
 
-  const [userTennisProfile, setUserTennisProfile] = useState<TennisProfile>();
+  const [currentMyEquipment, setCurrentMyEquipment] = useState<MyEquipment>();
+
 
   //my_equipmentの登録に使うstate群
   const [stringingWay, setStringingWay] = useState<string>('');
-  console.log('stringingWay', stringingWay)
 
   const [mainGut, setMainGut] = useState<Gut>();
-  console.log('mainGut', mainGut)
 
   const [crossGut, setCrossGut] = useState<Gut>();
-  console.log('crossGut', crossGut)
 
   const [racket, setRacket] = useState<Racket>();
-  console.log('racket', racket)
 
   //要素の表示などに使用するstate群
   const [makers, setMakers] = useState<Maker[]>();
@@ -52,25 +44,18 @@ const MyEquipmentEdit: NextPage = () => {
 
   // inputに関するstate
   const [inputMainGutGuage, setInputMainGutGuage] = useState<number>();
-  console.log('inputMainGutGuage', inputMainGutGuage)
 
   const [inputCrossGutGuage, setInputCrossGutGuage] = useState<number>();
-  console.log('inputCrossGutGuage', inputCrossGutGuage)
 
   const [inputMainGutTension, setInputMainGutTension] = useState<number>();
-  console.log('inputMainGutTension', inputMainGutTension)
 
   const [inputMainCrossTension, inputCrossGutTension] = useState<number>();
-  console.log('inputMainCrossTension', inputMainCrossTension)
 
   const [inputNewGutDate, setInputNewGutDate] = useState<string>();
-  console.log('inputNewGutDate', inputNewGutDate)
 
   const [inputChangeGutDate, setInputChangeGutDate] = useState<string | null | undefined>();
-  console.log('inputChangeGutDate', inputChangeGutDate)
 
   const [comment, setComment] = useState<string>('');
-  console.log('comment', comment)
 
   //モーダルの開閉に関するstate
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
@@ -93,12 +78,6 @@ const MyEquipmentEdit: NextPage = () => {
       })
     }
 
-    const getUserTennisProfile = async () => {
-      await axios.get(`api/tennis_profiles/${user.id}`).then(res => {
-        setUserTennisProfile(res.data);
-      })
-    }
-
     const getCurrentMyEquipment = async () => {
       await axios.get(`api/my_equipments/${currentMyEquipmentId}`).then(res => {
         const myEquipment: MyEquipment = res.data;
@@ -118,7 +97,6 @@ const MyEquipmentEdit: NextPage = () => {
     }
 
     getCurrentMyEquipment();
-    getUserTennisProfile();
     getMakerList();
   }, [])
 
@@ -574,7 +552,7 @@ const MyEquipmentEdit: NextPage = () => {
                         <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
                           <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
 
-                          <div className="border rounded py-[8px] mb-[16px] mb-auto">
+                          <div className="border rounded py-[8px] mb-[16px]">
                             <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[2px]">{racket ? racket.maker.name_en : ''}</p>
                             <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{racket ? racket.name_ja : '未選択'}</p>
                           </div>

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -1,0 +1,12 @@
+import { NextPage } from "next";
+
+
+const MyEquipmentEdit: NextPage = () => {
+  return (
+    <>
+      <h1>マイ装備編集ページ</h1>
+    </>
+  );
+}
+
+export default MyEquipmentEdit;

--- a/src/pages/my_equipments/[id]/my_equipment.tsx
+++ b/src/pages/my_equipments/[id]/my_equipment.tsx
@@ -7,6 +7,7 @@ import axios from "@/lib/axios";
 import AuthCheck from "@/components/AuthCheck";
 import SubHeading from "@/components/SubHeading";
 import TextUnderBar from "@/components/TextUnderBar";
+import Link from "next/link";
 
 const MyEquipment = () => {
   const router = useRouter();
@@ -154,6 +155,13 @@ const MyEquipment = () => {
                     <p className="w-[100%] max-w-[300px] min-h-[160px] border p-2 md:max-w-[360px] md:min-h-[267px]" >{myEquipment?.comment}</p>
                   </div>
                 </div>
+              </div>
+
+              <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-[24px] md:justify-end md:max-w-[768px]">
+                <Link
+                  href={`/my_equipments/${myEquipmentId}/edit`}
+                  className="inline-block  text-[14px] text-white text-center leading-[32px] font-bold w-[80px] h-[32px] rounded  bg-sub-green md:text-[16px] md:w-[100px]"
+                >編集</Link>
               </div>
             </div>
           </div>

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -43,7 +43,7 @@ export type MyEquipment = {
   main_gut_tension: number,
   cross_gut_tension: number,
   new_gut_date: string,
-  change_gut_date: null,
+  change_gut_date: undefined | null | string,
   comment: string,
   created_at: string,
   updated_at: string,


### PR DESCRIPTION
背景：
my_equipment登録ページのコードを参考に編集ページを作成する

やったこと：
- [x] my_equipment詳細ページに編集ページへのリンクを作成
- [x] my-equipment登録ページのコードをコピー（本格的なコードの編集はまだ）
- [x] コピーしたコードを編集していく
  - [x] importのpathを修正
  - [x] 更新ページの初期表示ようにMyEquipment初期データの取得処理を実装
  - [x] 取得した初期データを元にページのinputタグなどに初期値を表示させる
  - [x] その際、MyEquipmentの型のchange_gut_dateの方を修正
  - [x] updateMyEquipmentメソッドで更新処理を実装
  - [x] 確認のために書いていたconsole.logなどと不要なstateを削除

備考：
変更行が多いためcommit単位で目を通していただいて、最後に全体のコードにコメントなどをいただけるとレビューが簡単かと思います。

レビューお願いします。