### PR TITLE
add: テニスプロフィールの使用ラケットの更新機能の実装

### DIFF
--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -68,7 +68,7 @@ export type TennisProfile = {
 
 const UserProfile: NextPage = () => {
   const router = useRouter();
-  
+
   const { isAuth, user } = useContext(AuthContext);
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
@@ -76,7 +76,7 @@ const UserProfile: NextPage = () => {
   const [tennisProfile, setTennisProfile] = useState<TennisProfile>();
 
   useEffect(() => {
-    if(user.id) {
+    if (user.id) {
       const getTennisProfile = async () => {
         await axios.get(`api/tennis_profiles/${user.id}`).then(res => {
           setTennisProfile(res.data);
@@ -129,11 +129,16 @@ const UserProfile: NextPage = () => {
                   <div className="flex flex-wrap justify-between mb-8">
                     <p className="mb-2 basis-full">使用ラケット</p>
                     <div className="w-28 h-40 bg-faint-green">
-                      <img src={`${baseImagePath}images/rackets/defalt_racket_image.jpg`} width="112px" alt="ラケット画像" />
+                      {/* {racket && racket.racket_image.file_path */}
+                      { tennisProfile?.racket.racket_image.file_path
+                        ? <img src={`${baseImagePath}${tennisProfile.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                        : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                      }
+                      {/* <img src={`${baseImagePath}images/rackets/defalt_racket_image.jpg`} width="112px" alt="ラケット画像" /> */}
                     </div>
                     <div className="w-44 flex flex-col">
-                      <span className="inline-block pl-2 text-xs mb-2">Babolat</span>
-                      <p className="pl-2 leading-[18px] mb-4">ピュアアエロ</p>
+                      <span className="inline-block pl-2 text-xs mb-2">{tennisProfile?.racket ? tennisProfile?.racket.maker.name_en : ''}</span>
+                      <p className="pl-2 leading-[18px] mb-4">{tennisProfile?.racket ? tennisProfile?.racket.name_ja : '未選択'}</p>
                       <hr className="border-sub-green" />
                     </div>
                   </div>


### PR DESCRIPTION
issue: #50 

背景：
今まではbackend側のラケット検索機能の実装がまだでテニスプロフィールの使用ラケットの登録・変更処理を仮実装としており、またユーザープロフィールでのテニスプロフィール、使用中ラケット部分の情報表示を仮の画像と文字列で表示していた。

やったこと：

- [ ] テニスプロフィール更新画面でラケットをモーダルで検索・選択して使用ラケットを更新する処理を実装
- [ ] ユーザープロフィールでその使用中ラケットを表示できるように修正

レビューお願いします。