### PR TITLE
add: gut一覧ページにページネーション機能を追加

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -53,7 +53,6 @@ const Pagination: React.FC<PaginationProps> = ({ paginator, paginate, className 
 
   return (
     <>
-      {/* <div className={`w-[100%] max-w-[320px] mx-auto md:max-w-[768px] ${className} mt-[24px] md:mt-[48px] `}> */}
       <div className={`w-[100%] max-w-[320px] mx-auto md:max-w-[768px] ${className}`}>
         <ul className="flex flex-wrap justify-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex-nowrap">
           <div className="order-2 flex w-[100%] max-w-[96px] h-[24px] md:order-1 md:h-[32px]">

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,140 @@
+import type { Gut } from "@/pages/reviews";
+import type { Racket } from "@/pages/users/[id]/profile";
+import React from "react";
+
+type PaginationLinkData = {
+  url: string | null,
+  label: string,
+  active: boolean
+}
+
+export type Paginator<T> = {
+  current_page: number,
+  data: T[],
+  first_page_url: string,
+  from: number,
+  last_page: number,
+  last_page_url: string,
+  links: PaginationLinkData[],
+  next_page_url: string,
+  path: string,
+  per_page: number,
+  prev_page_url: string | null,
+  to: number,
+  total: number
+}
+
+type PaginationProps = {
+  // ページネーションさせたい項目分だけpaginatorの型を増やして使う
+  paginator?: Paginator<Gut> | Paginator<Racket>,
+  //ページネイトリンクをクリックした時にデータをfetchするための関数が渡ってくる
+  paginate: (url?: string) => Promise<void>,
+  className?: string
+}
+
+// laravelのpagenateメソッドを使うことを前提として作成している
+const Pagination: React.FC<PaginationProps> = ({ paginator, paginate, className }) => {
+  const paginateHandler = (url?: string) => {
+    if (url) {
+      paginate(url);
+    }
+  }
+
+  //fullUrlをaxiosでbaseUrlを設定しているときなどに必要な部分のみ返すため
+  const removeBaseUrl = (fullUrl?: string): string | undefined => {
+    const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+
+    if (fullUrl && baseUrl) {
+      return fullUrl.replace(baseUrl, "");
+    }
+
+    return undefined
+  }
+
+  return (
+    <>
+      {/* <div className={`w-[100%] max-w-[320px] mx-auto md:max-w-[768px] ${className} mt-[24px] md:mt-[48px] `}> */}
+      <div className={`w-[100%] max-w-[320px] mx-auto md:max-w-[768px] ${className}`}>
+        <ul className="flex flex-wrap justify-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex-nowrap">
+          <div className="order-2 flex w-[100%] max-w-[96px] h-[24px] md:order-1 md:h-[32px]">
+            <li className="inline-block w-[48px] text-center grow-1 border rounded-l-sm md:rounded-l">
+              <a
+                onClick={() => paginateHandler(removeBaseUrl(paginator?.first_page_url))}
+                className="inline-block cursor-pointer w-[100%] max-w-[48px] md:leading-[32px]"
+                aria-disabled={paginator?.current_page === 1}
+              >
+                最初
+              </a>
+            </li>
+
+            <li className="inline-block w-[48px] text-center border-y border-r">
+              <a
+                onClick={() => {
+                  if (paginator?.prev_page_url) {
+                    const url = removeBaseUrl(paginator?.prev_page_url);
+                    paginateHandler(url)
+                  }
+                }}
+                className={`inline-block cursor-pointer w-[100%] max-w-[48px] ${paginator?.prev_page_url ?? 'opacity-30 !cursor-default'} md:leading-[32px]`}
+                aria-disabled={!(paginator?.prev_page_url)}
+              >
+                前へ
+              </a>
+            </li>
+          </div>
+
+          <div className="flex justify-center order-1 w-[100%] max-w-[320px] mb-[8px] md:order-2 md:w-auto md:max-w-none md:mb-0">
+            {paginator?.links.map((link, index) => {
+              //前へと次へは表示の関係上、別でリンクを用意する
+              if (index === 0 || index === paginator.links.length - 1) return;
+
+              return (
+                <>
+                  <li className="inline-block w-[24px] h-[24px] text-center border-y border-l  [&:last-child]:border-r [&:first-child]:rounded-l-sm [&:last-child]:rounded-r-sm md:w-[32px] md:h-[32px] md:[&:first-child]:rounded-l-none md:[&:last-child]:rounded-r-none md:[&:first-child]:border-l-0 md:[&:last-child]:border-r-0">
+                    <a
+                      type="button"
+                      onClick={() => paginateHandler(removeBaseUrl(link.url ? link.url : undefined))}
+                      className={`cursor-pointer w-[100%] h-[100%] text-center ${link.active && 'text-sub-green bg-faint-green'} md:leading-[32px]`}
+                      aria-disabled={link.active}
+                    >
+                      {link.label}
+                    </a>
+                  </li>
+                </>
+              )
+            })}
+          </div>
+
+          <div className="order-4 flex md:order-3 h-[24px] md:h-[32px]">
+            <li className="inline-block w-[48px] text-center border h-[24px] md:h-[32px]">
+              <a
+                onClick={() => paginateHandler(removeBaseUrl(paginator?.next_page_url))}
+                className={`inline-block cursor-pointer w-[100%] max-w-[48px] h-[100%] ${paginator?.next_page_url ?? 'opacity-30 !cursor-default'} md:leading-[32px]`}
+                aria-disabled={!(paginator?.next_page_url)}
+              >
+                次へ
+              </a>
+            </li>
+
+            <li className="inline-block w-[48px] text-center border-y border-r rounded-r-sm md:h-[32px] md:rounded-r">
+              <a
+                onClick={() => paginateHandler(removeBaseUrl(paginator?.last_page_url))}
+                className="inline-block cursor-pointer w-[100%] max-w-[48px] h-[100%] md:leading-[32px]"
+                aria-disabled={paginator?.current_page === paginator?.last_page}
+              >
+                最後
+              </a>
+            </li>
+          </div>
+
+          <span className="order-3 w-[100%] max-w-[120px] h-[24px] text-center border-y md:order-4 md:hidden">
+            {paginator?.current_page} / {paginator?.last_page}
+          </span>
+
+        </ul>
+      </div>
+    </>
+  );
+}
+
+export default Pagination;

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -11,28 +11,7 @@ import TextUnderBar from "@/components/TextUnderBar";
 import PrimaryHeading from "@/components/PrimaryHeading";
 import { Adamina } from "next/font/google";
 import { IoClose } from "react-icons/io5";
-
-type PaginationLinkData = {
-  url: string | null,
-  label: string,
-  active: boolean
-}
-
-type Paginator<T> = {
-  current_page: number,
-  data: T[],
-  first_page_url: string,
-  from: number,
-  last_page: number,
-  last_page_url: string,
-  links: PaginationLinkData[],
-  next_page_url: string,
-  path: string,
-  per_page: number,
-  prev_page_url: string | null,
-  to: number,
-  total: number
-}
+import Pagination, {type Paginator } from "@/components/Pagination";
 
 const GutList = () => {
   const router = useRouter();
@@ -122,24 +101,6 @@ const GutList = () => {
 
   }
 
-  const paginateHandler = (url?: string) => {
-    console.log('url', url)
-    if (url) {
-      getGutsList(url);
-    }
-  }
-
-  //fullUrlをaxiosでbaseUrlを設定しているときなどに必要な部分のみ返すため
-  const removeBaseUrl = (fullUrl?: string): string | undefined => {
-    const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL
-
-    if (fullUrl && baseUrl) {
-      return fullUrl.replace(baseUrl, "");
-    }
-
-    return undefined
-  }
-
   return (
     <>
       <AuthCheck>
@@ -181,7 +142,7 @@ const GutList = () => {
             </div>
 
             {/* ガットセクション */}
-            <div className="mb-[32px]">
+            <div className="">
               <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
                 {/* ガット */}
                 {guts && guts.map(gut => (
@@ -235,85 +196,11 @@ const GutList = () => {
             </div>
 
             {/* ページネーション */}
-            <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] mt-[24px] md:mt-[48px]">
-              <ul className="flex flex-wrap justify-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex-nowrap">
-                <div className="order-2 flex w-[100%] max-w-[96px] h-[24px] md:order-1 md:h-[32px]">
-                  <li className="inline-block w-[48px] text-center grow-1 border rounded-l-sm md:rounded-l">
-                    <a
-                      onClick={() => paginateHandler(removeBaseUrl(gutsPaginator?.first_page_url))}
-                      className="inline-block cursor-pointer w-[100%] max-w-[48px] md:leading-[32px]"
-                      aria-disabled={gutsPaginator?.current_page === 1}
-                    >
-                      最初
-                    </a>
-                  </li>
-
-                  <li className="inline-block w-[48px] text-center border-y border-r">
-                    <a
-                      onClick={() => {
-                        if (gutsPaginator?.prev_page_url) {
-                          const url = removeBaseUrl(gutsPaginator?.prev_page_url);
-                          paginateHandler(url)
-                        }
-                      }}
-                      className={`inline-block cursor-pointer w-[100%] max-w-[48px] ${gutsPaginator?.prev_page_url ?? 'opacity-30 !cursor-default'} md:leading-[32px]`}
-                      aria-disabled={!(gutsPaginator?.prev_page_url)}
-                    >
-                      前へ
-                    </a>
-                  </li>
-                </div>
-
-                <div className="flex justify-center order-1 w-[100%] max-w-[320px] mb-[8px] md:order-2 md:w-auto md:max-w-none md:mb-0">
-                  {gutsPaginator?.links.map((link, index) => {
-                    //前へと次へは表示の関係上、別でリンクを用意する
-                    if (index === 0 || index === gutsPaginator.links.length - 1) return;
-
-                    return (
-                      <>
-                        <li className="inline-block w-[24px] h-[24px] text-center border-y border-l  [&:last-child]:border-r [&:first-child]:rounded-l-sm [&:last-child]:rounded-r-sm md:w-[32px] md:h-[32px] md:[&:first-child]:rounded-l-none md:[&:last-child]:rounded-r-none md:[&:first-child]:border-l-0 md:[&:last-child]:border-r-0">
-                          <a
-                            type="button"
-                            onClick={() => paginateHandler(removeBaseUrl(link.url ? link.url : undefined))}
-                            className={`cursor-pointer w-[100%] h-[100%] text-center ${link.active && 'text-sub-green bg-faint-green'} md:leading-[32px]`}
-                            aria-disabled={link.active}
-                          >
-                            {link.label}
-                          </a>
-                        </li>
-                      </>
-                    )
-                  })}
-                </div>
-
-                <div className="order-4 flex md:order-3 h-[24px] md:h-[32px]">
-                  <li className="inline-block w-[48px] text-center border h-[24px] md:h-[32px]">
-                    <a
-                      onClick={() => paginateHandler(removeBaseUrl(gutsPaginator?.next_page_url))}
-                      className={`inline-block cursor-pointer w-[100%] max-w-[48px] h-[100%] ${gutsPaginator?.next_page_url ?? 'opacity-30 !cursor-default'} md:leading-[32px]`}
-                      aria-disabled={!(gutsPaginator?.next_page_url)}
-                    >
-                      次へ
-                    </a>
-                  </li>
-
-                  <li className="inline-block w-[48px] text-center border-y border-r rounded-r-sm md:h-[32px] md:rounded-r">
-                    <a
-                      onClick={() => paginateHandler(removeBaseUrl(gutsPaginator?.last_page_url))}
-                      className="inline-block cursor-pointer w-[100%] max-w-[48px] h-[100%] md:leading-[32px]"
-                      aria-disabled={gutsPaginator?.current_page === gutsPaginator?.last_page}
-                    >
-                      最後
-                    </a>
-                  </li>
-                </div>
-
-                <span className="order-3 w-[100%] max-w-[120px] h-[24px] text-center border-y md:order-4 md:hidden">
-                  {gutsPaginator?.current_page} / {gutsPaginator?.last_page}
-                </span>
-
-              </ul>
-            </div>
+            <Pagination
+              paginator={gutsPaginator}
+              paginate={getGutsList}
+              className="mt-[32px] md:mt-[48px]"
+            />
           </div>
         )}
       </AuthCheck>

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -181,7 +181,7 @@ const GutList = () => {
             </div>
 
             {/* ガットセクション */}
-            <div className="">
+            <div className="mb-[32px]">
               <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
                 {/* ガット */}
                 {guts && guts.map(gut => (
@@ -235,13 +235,13 @@ const GutList = () => {
             </div>
 
             {/* ページネーション */}
-            <div className="w-[100%] max-w-[320px] mx-auto">
-              <ul className="flex flex-wrap justify-center w-[100%] max-w-[320px] mx-auto">
-                <div className="order-2 flex w-[100%] max-w-[96px]">
-                  <li className="inline-block w-[48px] text-center grow-1 border rounded-l-sm">
+            <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] mt-[24px] md:mt-[48px]">
+              <ul className="flex flex-wrap justify-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex-nowrap">
+                <div className="order-2 flex w-[100%] max-w-[96px] h-[24px] md:order-1 md:h-[32px]">
+                  <li className="inline-block w-[48px] text-center grow-1 border rounded-l-sm md:rounded-l">
                     <a
                       onClick={() => paginateHandler(removeBaseUrl(gutsPaginator?.first_page_url))}
-                      className="inline-block cursor-pointer w-[100%] max-w-[48px]"
+                      className="inline-block cursor-pointer w-[100%] max-w-[48px] md:leading-[32px]"
                       aria-disabled={gutsPaginator?.current_page === 1}
                     >
                       最初
@@ -256,7 +256,7 @@ const GutList = () => {
                           paginateHandler(url)
                         }
                       }}
-                      className={`inline-block cursor-pointer w-[100%] max-w-[48px] ${gutsPaginator?.prev_page_url ?? 'opacity-30 !cursor-default'}`}
+                      className={`inline-block cursor-pointer w-[100%] max-w-[48px] ${gutsPaginator?.prev_page_url ?? 'opacity-30 !cursor-default'} md:leading-[32px]`}
                       aria-disabled={!(gutsPaginator?.prev_page_url)}
                     >
                       前へ
@@ -264,18 +264,18 @@ const GutList = () => {
                   </li>
                 </div>
 
-                <div className="flex justify-center order-1 w-[100%] max-w-[320px] mb-[8px]">
+                <div className="flex justify-center order-1 w-[100%] max-w-[320px] mb-[8px] md:order-2 md:w-auto md:max-w-none md:mb-0">
                   {gutsPaginator?.links.map((link, index) => {
                     //前へと次へは表示の関係上、別でリンクを用意する
                     if (index === 0 || index === gutsPaginator.links.length - 1) return;
 
                     return (
                       <>
-                        <li className="inline-block w-[24px] h-[24px] text-center border-y border-l  [&:last-child]:border-r [&:first-child]:rounded-l-sm [&:last-child]:rounded-r-sm">
+                        <li className="inline-block w-[24px] h-[24px] text-center border-y border-l  [&:last-child]:border-r [&:first-child]:rounded-l-sm [&:last-child]:rounded-r-sm md:w-[32px] md:h-[32px] md:[&:first-child]:rounded-l-none md:[&:last-child]:rounded-r-none md:[&:first-child]:border-l-0 md:[&:last-child]:border-r-0">
                           <a
                             type="button"
                             onClick={() => paginateHandler(removeBaseUrl(link.url ? link.url : undefined))}
-                            className={`cursor-pointer w-[100%] h-[100%] text-center ${link.active && 'text-sub-green bg-faint-green'}`}
+                            className={`cursor-pointer w-[100%] h-[100%] text-center ${link.active && 'text-sub-green bg-faint-green'} md:leading-[32px]`}
                             aria-disabled={link.active}
                           >
                             {link.label}
@@ -286,21 +286,21 @@ const GutList = () => {
                   })}
                 </div>
 
-                <div className="order-4 flex">
-                  <li className="inline-block w-[48px] text-center border">
+                <div className="order-4 flex md:order-3 h-[24px] md:h-[32px]">
+                  <li className="inline-block w-[48px] text-center border h-[24px] md:h-[32px]">
                     <a
                       onClick={() => paginateHandler(removeBaseUrl(gutsPaginator?.next_page_url))}
-                      className={`inline-block cursor-pointer w-[100%] max-w-[48px] ${gutsPaginator?.next_page_url ?? 'opacity-30 !cursor-default'}`}
+                      className={`inline-block cursor-pointer w-[100%] max-w-[48px] h-[100%] ${gutsPaginator?.next_page_url ?? 'opacity-30 !cursor-default'} md:leading-[32px]`}
                       aria-disabled={!(gutsPaginator?.next_page_url)}
                     >
                       次へ
                     </a>
                   </li>
 
-                  <li className="inline-block w-[48px] text-center border-y border-r rounded-r-sm">
+                  <li className="inline-block w-[48px] text-center border-y border-r rounded-r-sm md:h-[32px] md:rounded-r">
                     <a
                       onClick={() => paginateHandler(removeBaseUrl(gutsPaginator?.last_page_url))}
-                      className="inline-block cursor-pointer w-[100%] max-w-[48px]"
+                      className="inline-block cursor-pointer w-[100%] max-w-[48px] h-[100%] md:leading-[32px]"
                       aria-disabled={gutsPaginator?.current_page === gutsPaginator?.last_page}
                     >
                       最後
@@ -308,7 +308,7 @@ const GutList = () => {
                   </li>
                 </div>
 
-                <span className="order-3 w-[100%] max-w-[120px] text-center border-y">
+                <span className="order-3 w-[100%] max-w-[120px] h-[24px] text-center border-y md:order-4 md:hidden">
                   {gutsPaginator?.current_page} / {gutsPaginator?.last_page}
                 </span>
 


### PR DESCRIPTION
_**issue**_: #58 

_**背景：**_
gut一覧ページではfetchしてきたgut情報を全て一ページで表示されるようになっていたためデータが増えた時のためにページネーション機能を実装する

_**やったこと：**_

- [x] ページネーションに対応するため初期fetchとして作成していたgetGutsListメソッドを修正
- [x] laravelのpagenateメソッドでデータが渡ってくることを想定してpaginatorの型を用意
- [x] laravelから取得したpaginationのメタデータを使ってレイアウトと処理の実装
- [x] ページネーションを他ページでも利用できるようにコンポーネントに切り出し

_**備考：**_
laravelのpaginateメソッドで渡ってくるメタデータでnullで渡ってくるデータがあるため、各種型の定義が少し無理やり合わせたところがあるので改善の余地があると思います。また、undefinedを許容している箇所も少し気になっています。

レビューお願いします。