### PR TITLE
modify: racketイメージ登録画面でmakerの項目を変更後再度未選択にした時の挙動を修正

### DIFF
--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -41,6 +41,16 @@ const GutImageRegister: NextPage = () => {
     }
   }
 
+  const onChangeSelectMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if(e.target.value === '未選択') {
+      setSelectedMakerId(undefined);
+
+      return 
+    }
+
+    setSelectedMakerId(Number(e.target.value));
+  }
+
   useEffect(() => {
     const getMakerList = async () => {
       await axios.get('api/makers').then(res => {
@@ -153,7 +163,7 @@ const GutImageRegister: NextPage = () => {
                       <select
                         name="maker"
                         id="maker"
-                        onChange={(e) => { setSelectedMakerId(Number(e.target.value)) }}
+                        onChange={onChangeSelectMaker}
                         className="border border-gray-300 rounded w-[160px] md:w-[250px] h-10 p-2 focus:outline-sub-green"
                       >
                         <option value="未選択" selected>未選択</option>


### PR DESCRIPTION
issue: #66 

背景：
racketイメージ登録画面のmakerの項目を一度変更してから再度未選択にした時maker_idのstateにNaNが格納され登録が失敗した際のエラー文が開発者向けのものになってしまっていた

やったこと：
maker_idのselect ボックスのchangeイベント関数を別で用意してその中で条件分岐によって未選択を選択した時にmaker_idのstateにundefinedが格納されるように修正した

備考：
undefinedを登録処理に使うことでlaravelのvalidationのrequiredに引っかかるので、このエラー文はユーザー向けとなる

レビューお願いします
再度未選択にした時NaNがmaker_idのstateに格納されてしまいエラー文が開発者向けのものになっていたため修正