### PR TITLE
fix: ログインユーザーに紐つくtennisProfile情報を取得するように修正とそれに影響するファイルの修正

### DIFF
--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -46,7 +46,7 @@ const TennisProfileEdit: NextPage = () => {
   useEffect(() => {
     if (user.id) {
       const getTennisProfile = async () => {
-        await axios.get(`api/tennis_profiles/${user.id}`).then(res => {
+        await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
           setTennisProfile(res.data);
           setExperiencePeriod(res.data.experience_period);
           setFrequency(res.data.frequency);
@@ -104,7 +104,7 @@ const TennisProfileEdit: NextPage = () => {
           maker: inputSearchMaker
         }
       }).then((res) => {
-        setSearchedRackets(res.data);
+        setSearchedRackets(res.data.data);
       })
 
       console.log('検索完了しました')
@@ -284,7 +284,7 @@ const TennisProfileEdit: NextPage = () => {
 
     await csrf();
 
-    await axios.post(`/api/tennis_profiles/${user.id}`, updatedData, {
+    await axios.post(`/api/tennis_profiles/${tennisProfile?.id}`, updatedData, {
       headers: {
         'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
       }

--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -104,7 +104,7 @@ const TennisProfileEdit: NextPage = () => {
           maker: inputSearchMaker
         }
       }).then((res) => {
-        setSearchedRackets(res.data.data);
+        setSearchedRackets(res.data);
       })
 
       console.log('検索完了しました')

--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -50,6 +50,7 @@ export type Racket = {
 }
 
 export type TennisProfile = {
+  id: number,
   user_id: number,
   my_racket_id?: number,
   experience_period: number,
@@ -78,7 +79,7 @@ const UserProfile: NextPage = () => {
   useEffect(() => {
     if (user.id) {
       const getTennisProfile = async () => {
-        await axios.get(`api/tennis_profiles/${user.id}`).then(res => {
+        await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
           setTennisProfile(res.data);
         })
       }
@@ -128,14 +129,14 @@ const UserProfile: NextPage = () => {
 
                   <div className="flex flex-wrap justify-between mb-8">
                     <p className="mb-2 basis-full">使用ラケット</p>
+
                     <div className="w-28 h-40 bg-faint-green">
-                      {/* {racket && racket.racket_image.file_path */}
-                      { tennisProfile?.racket.racket_image.file_path
+                      { tennisProfile?.racket?.racket_image.file_path
                         ? <img src={`${baseImagePath}${tennisProfile.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                         : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                       }
-                      {/* <img src={`${baseImagePath}images/rackets/defalt_racket_image.jpg`} width="112px" alt="ラケット画像" /> */}
                     </div>
+                    
                     <div className="w-44 flex flex-col">
                       <span className="inline-block pl-2 text-xs mb-2">{tennisProfile?.racket ? tennisProfile?.racket.maker.name_en : ''}</span>
                       <p className="pl-2 leading-[18px] mb-4">{tennisProfile?.racket ? tennisProfile?.racket.name_ja : '未選択'}</p>


### PR DESCRIPTION
issue: #30 

背景：
ユーザー新規登録の際にtennisProfileが一緒に作られるが、登録後のprofileページでこのtennisProfileの情報を正しく取得できていなかったことによる404エラーが発生していた

やったこと：

- [ ] ユーザー登録後、profileページにてログイン中のユーザーのtennisProfileを取得するapiを叩くように変更
- [ ] また、影響範囲となるtennis_profile編集ページでの初期tennisProfileデータの取得箇所も利用するapiを変更した

備考：
この修正に伴い、backend laravel側でTennisProfileControllerにgetCurrentUserTennisProfileメソッドを新たにapiとして作成した

レビューお願いします