### PR TITLE
modify:サイトリロード時の認証チェックの修正

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -79,12 +79,10 @@ const AuthContextProvidor: React.FC<AuthContextProvidorProps> = ({ children }) =
     }
   }
 
-  useLayoutEffect(() => {
-    if (router.pathname.startsWith('/users')) {
-      checkAuth('user', setUser, setIsAuth);
-    } else if (router.pathname.startsWith('/admins')) {
-      checkAuth('admin', setAdmin, setIsAuthAdmin);
-    }
+  useEffect(() => {
+    checkAuth('user', setUser, setIsAuth);
+    
+    checkAuth('admin', setAdmin, setIsAuthAdmin);
   }, []);
 
   const providorVal = {


### PR DESCRIPTION
_**issue:**_ #74 

_**背景：**_
urlで直接リロードした際に'/users'、'/admins'で始まるページ以外再度認証チェックが行われず、認証関連のstateが再度セットされないためログインを再度するかログインページでリロードして認証チェックを走らせるかをしなければいけなくなり、開発時やユーザー利用時に不便である

_**やったこと：**_

- [ ] AuthContext.tsxでcheckAuthメソッドをリロード時に毎回実行されるように修正
- [ ] useLayoutEffectを使っていたがuseEffectに修正

_**備考：**_
サイトリロード時に毎回認証チェックで認証関連のstateに値をセットしており、headerのリンクがログイン中の表示になるようになっているが、サイトのページとしてはログイン画面に遷移されるようになっているので、リロードが行われたページのまま再度認証チェックが行われるようにできるとより良いと思います。今回はその修正は行っていないので将来的に修正できればと思います。

レビューお願いします