### PR TITLE
modify: my_equipment登録ページで叩いているtennisProfile情報取得apiの変更

### DIFF
--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -76,7 +76,7 @@ const MyEquipmentRegister: NextPage = () => {
     }
 
     const getUserTennisProfile = async () => {
-      await axios.get(`api/tennis_profiles/${user.id}`).then(res => {
+      await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
         setUserTennisProfile(res.data);
       })
     }


### PR DESCRIPTION
issue: #71 

背景：
今まではbackend laravelのseederで用意していたuser, tennisProfileを使ってい動作しており、フロント側から新たにユーザーを作成した際に同時に作成されるtennisProfileのidとのずれによりmy_equipment登録ページで取得しているtennisProfile情報が正しく取ってこれていない事象が発生していた

やったこと：

- [ ] my_equipmentで叩いているtennisProfile情報取得apiをuserに紐つくtennisProfile情報取得apiを叩くように変更

レビューお願いします