### PR TITLE
modify: my_equipment登録・編集ページで各種検索モーダルの表示とスクロールの不具合の修正

### DIFF
--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -59,7 +59,11 @@ const MyEquipmentEdit: NextPage = () => {
   const [comment, setComment] = useState<string>('');
 
   //モーダルの開閉に関するstate
+  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
+
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
 
   const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
@@ -106,6 +110,42 @@ const MyEquipmentEdit: NextPage = () => {
     getMakerList();
   }, [])
 
+  // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (modalVisibility) {
+      setModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [modalVisibility])
+
+  // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (racketSearchModalVisibility) {
+      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [racketSearchModalVisibility])
+
   //inputの制御関数群
   const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setStringingWay(e.target.value);
@@ -139,6 +179,7 @@ const MyEquipmentEdit: NextPage = () => {
 
   //モーダルの開閉
   const closeModal = () => {
+    setModalVisibility(false);
     setModalVisibilityClassName('opacity-0 scale-0')
     setWitchSelectingGut('');
   }
@@ -149,21 +190,25 @@ const MyEquipmentEdit: NextPage = () => {
 
   //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
   const openMainGutSearchModal = () => {
+    setModalVisibility(true);
     openModal();
     setWitchSelectingGut('main');
   }
 
   const openCrossGutSearchModal = () => {
+    setModalVisibility(true);
     openModal();
     setWitchSelectingGut('cross');
   }
 
   //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
   const openRacketSearchModal = () => {
+    setRacketSearchModalVisibility(true);
     setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
+    setRacketSearchModalVisibility(false)
     setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
@@ -199,7 +244,7 @@ const MyEquipmentEdit: NextPage = () => {
       setSearchedRackets(res.data.data);
     })
   }
-  
+
   //racket検索
   const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
@@ -604,7 +649,7 @@ const MyEquipmentEdit: NextPage = () => {
                 </form>
 
                 {/* gut検索モーダル */}
-                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
                   <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
                     <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
                       <IoClose size={48} />
@@ -666,7 +711,7 @@ const MyEquipmentEdit: NextPage = () => {
                 </div>
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
                   <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
                     <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
                       <IoClose size={48} />
@@ -716,7 +761,7 @@ const MyEquipmentEdit: NextPage = () => {
                           </>
                         ))}
                       </div>
-                      
+
                       <Pagination
                         paginator={racketsPaginator}
                         paginate={getSearchedRacketsList}

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -56,7 +56,11 @@ const MyEquipmentRegister: NextPage = () => {
   const [comment, setComment] = useState<string>('');
 
   //モーダルの開閉に関するstate
+  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
+
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
 
   const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
@@ -68,7 +72,7 @@ const MyEquipmentRegister: NextPage = () => {
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
 
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
-  
+
   const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
 
   const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
@@ -89,6 +93,42 @@ const MyEquipmentRegister: NextPage = () => {
     getUserTennisProfile();
     getMakerList();
   }, [])
+
+  // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (modalVisibility) {
+      setModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [modalVisibility])
+
+  // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (racketSearchModalVisibility) {
+      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [racketSearchModalVisibility])
 
   //inputの制御関数群
   const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -123,6 +163,7 @@ const MyEquipmentRegister: NextPage = () => {
 
   //モーダルの開閉
   const closeModal = () => {
+    setModalVisibility(false);
     setModalVisibilityClassName('opacity-0 scale-0')
     setWitchSelectingGut('');
   }
@@ -133,21 +174,25 @@ const MyEquipmentRegister: NextPage = () => {
 
   //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
   const openMainGutSearchModal = () => {
+    setModalVisibility(true);
     openModal();
     setWitchSelectingGut('main');
   }
 
   const openCrossGutSearchModal = () => {
+    setModalVisibility(true);
     openModal();
     setWitchSelectingGut('cross');
   }
 
   //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
   const openRacketSearchModal = () => {
+    setRacketSearchModalVisibility(true);
     setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
+    setRacketSearchModalVisibility(false)
     setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
@@ -586,8 +631,8 @@ const MyEquipmentRegister: NextPage = () => {
                 </form>
 
                 {/* gut検索モーダル */}
-                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
                     <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
                       <IoClose size={48} />
                     </div>
@@ -649,7 +694,7 @@ const MyEquipmentRegister: NextPage = () => {
                 </div>
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
                   <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
                     <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
                       <IoClose size={48} />


### PR DESCRIPTION
issue: #77 

背景：
検索モーダルなどでモーダルを開いた時に、モーダルの位置とスクロールの位置が適切でなくずれてしまう。また検索結果をページネーション表示させた時に中身の量によってモーダルの高さが小さくなりずれてしまう。加えて、スクロールの挙動がおかしくなっている

再現手順：

- [ ] userでログインする
- [ ] マイ装備登録ページに遷移する
- [ ] racektもしくはgut検索モーダルを表示させる
- [ ] モーダルの位置が上部にありスクロールさせる必要が生じるのが確認できる
- [ ] 検索してみる
- [ ] モーダルのスクロールと上位コンポーネントのスクロールが混在しており、背景がスクロールされてしまっているのが確認できる。
- [ ] マイ装備編集ページも同様

やったこと；
マイ装備登録ページにて
- [ ] 各種モーダルのclassNameにfixed top-0 overflow-y-scrollをして意思表示位置をモーダル開閉ボタンを押した時点での位置に固定しつつスクロール可に変更
- [ ] モーダルの開閉をstate modalVisibility, racketSearchModalVisibility boolean型で管理するよう記述
- [ ] useEffect内でmodalVisibility, racketSearchModalVisibilityによってモーダル表示時にモーダル内以外のスクロールを停止させるように記述


レビューお願いします