### PR TITLE
modify: 各種ページの上部の余白の調整

### DIFF
--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -141,7 +141,7 @@ const GutImageRegister: NextPage = () => {
         {(isAuth || isAuthAdmin) && (
           <>
             <div className="container mx-auto mb-[48px]">
-              <div className="text-center mb-6 md:mb-[48px]">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="ストリング画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -193,9 +193,9 @@ const GutEdit: NextPage = () => {
         {isAuthAdmin && (
           <>
 
-            <div className="container mx-auto mb-8 w-screen pt-[24px] overflow-y-auto">
+            <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 
-              <div className="text-center mb-6">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="ストリング情報更新" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -49,8 +49,8 @@ const Gut = () => {
         {(isAuth || isAuthAdmin) && (
           <>
             <div className="container md:mx-auto">
-              <div className="text-center mb-6 md:mb-[48px]">
-                <PrimaryHeading text="String" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+              <div className="text-center my-6 md:my-[32px]">
+                <PrimaryHeading text="String" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               {/* ガットセクション */}

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -105,9 +105,9 @@ const GutList = () => {
     <>
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
-          <div className="container mx-auto md:mt-[32px]">
-            <div className="text-center mb-6 md:mb-[32px]">
-              <PrimaryHeading text="Strings" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+          <div className="container mx-auto">
+            <div className="text-center my-6 md:my-[32px]">
+              <PrimaryHeading text="Strings" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
             </div>
 
             <div className="flex justify-center mb-[48px] md:justify-end w-[100%] max-w-[768px] mx-auto">

--- a/src/pages/guts/register.tsx
+++ b/src/pages/guts/register.tsx
@@ -174,9 +174,9 @@ const GutRegister: NextPage = () => {
         {isAuthAdmin && (
           <>
 
-            <div className="container mx-auto mb-8 w-screen pt-[24px] overflow-y-auto">
+            <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 
-              <div className="text-center mb-6">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="ストリング登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -358,8 +358,8 @@ const MyEquipmentEdit: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
-            <div className="container mx-auto mt-[24px] md:mt-[48px]">
-              <div className="text-center mb-6 md:mb-[48px]">
+            <div className="container mx-auto">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/my_equipments/[id]/my_equipment.tsx
+++ b/src/pages/my_equipments/[id]/my_equipment.tsx
@@ -8,6 +8,7 @@ import AuthCheck from "@/components/AuthCheck";
 import SubHeading from "@/components/SubHeading";
 import TextUnderBar from "@/components/TextUnderBar";
 import Link from "next/link";
+import PrimaryHeading from "@/components/PrimaryHeading";
 
 const MyEquipment = () => {
   const router = useRouter();
@@ -41,8 +42,8 @@ const MyEquipment = () => {
           // <h1>マイ装備詳細</h1>
           <div className="container mb-8 mx-auto">
             <div className=" w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-              <div className="mb-6">
-                <h1 className="text-[18px] text-center">Equipment</h1>
+              <div className="text-center my-6 md:mb-[32px]">
+                <PrimaryHeading text="Equipment" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               <div className="md:flex md:flex-col md:max-h-[700px] md:flex-wrap">

--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -5,6 +5,7 @@ import axios from "@/lib/axios";
 import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
 import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
 
 const MyEquipmentList = () => {
   const router = useRouter();
@@ -35,8 +36,8 @@ const MyEquipmentList = () => {
         {isAuth && (
           <>
             <div className="container mx-auto px-2">
-              <div className="mb-4">
-                <h1 className="text-center text-[20px] md:text-[32px]">Equipments</h1>
+              <div className="text-center my-6 md:my-[32px]">
+                <PrimaryHeading text="Equipments" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               <div className="flex justify-center mb-6 md:w-[784px] md:mx-auto md:justify-end">

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -342,8 +342,8 @@ const MyEquipmentRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
-            <div className="container mx-auto mt-[24px] md:mt-[48px]">
-              <div className="text-center mb-6 md:mb-[48px]">
+            <div className="container mx-auto">
+              <div className="text-center my-6 md:mb-[32px]">
                 <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -142,7 +142,7 @@ const GutImageRegister: NextPage = () => {
         {(isAuth || isAuthAdmin) && (
           <>
             <div className="container mx-auto mb-[48px]">
-              <div className="text-center mb-6 md:mb-[48px]">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="ラケット画像登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/rackets/[id]/edit.tsx
+++ b/src/pages/rackets/[id]/edit.tsx
@@ -184,9 +184,9 @@ const RacketEdit: NextPage = () => {
         {isAuthAdmin && (
           <>
 
-            <div className="container mx-auto mb-8 w-screen pt-[24px] overflow-y-auto">
+            <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 
-              <div className="text-center mb-6">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="ラケット情報更新" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/rackets/[id]/index.tsx
+++ b/src/pages/rackets/[id]/index.tsx
@@ -50,8 +50,8 @@ const RacketShow = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <div className="container mx-auto">
-            <div className="text-center mb-6 md:mb-[48px]">
-              <PrimaryHeading text="Rackets" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+            <div className="text-center my-6  md:my-[32px]">
+              <PrimaryHeading text="Racket" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
             </div>
 
             {/* ラケットセクション */}

--- a/src/pages/rackets/index.tsx
+++ b/src/pages/rackets/index.tsx
@@ -105,7 +105,7 @@ const RacketList = () => {
           <>
             <div className="container mx-auto mt-[24px] md:mt-[32px]">
               <div className="text-center mb-6 md:mb-[32px]">
-                <PrimaryHeading text="Rackets" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+                <PrimaryHeading text="Rackets" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               {/* 検索 */}

--- a/src/pages/rackets/register.tsx
+++ b/src/pages/rackets/register.tsx
@@ -169,9 +169,9 @@ const RacketRegister: NextPage = () => {
         {isAuthAdmin && (
           <>
 
-            <div className="container mx-auto mb-8 w-screen pt-[24px] overflow-y-auto">
+            <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 
-              <div className="text-center mb-6">
+              <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="ラケット登録" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 

--- a/src/pages/reviews/[id]/review.tsx
+++ b/src/pages/reviews/[id]/review.tsx
@@ -34,8 +34,8 @@ const Review = () => {
       <AuthCheck>
         {isAuth && (
           <>
-            <h1 className="text-center mb-6 md:text-[24px]">Review</h1>
             <div className="container mx-auto">
+              <h1 className="text-center my-[24px] italic md:my-[32px] md:text-[24px]">Review</h1>
               <div className="flex flex-col items-center flex-wrap">
                 <div className="md:flex md:justify-center md:mb-[32px]">
                   {/* メインガット */}

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -95,7 +95,7 @@ const ReviewList = () => {
         {isAuth && (
           <>
             <div className="container mx-auto">
-              <div className="mb-4">
+              <div className="mb-6 mt-6 italic md:mb-[32px] md:mt-[32px]">
                 <h1 className="text-center text-[20px] md:text-[32px]">Reviews</h1>
               </div>
 

--- a/src/pages/users/[id]/edit/base_profile.tsx
+++ b/src/pages/users/[id]/edit/base_profile.tsx
@@ -128,7 +128,7 @@ const BaseProfileEdit: NextPage = () => {
           <>
             {/* <h1>プロフィールページ</h1> */}
             <div className="container mx-auto">
-              <div className="w-80 md:w-[500px] mx-auto flex flex-col md:justify-center">
+              <div className="w-80 mt-[24px] md:w-[500px] mx-auto flex flex-col md:justify-center md:mt-[48px]">
                 <div className="w-[320px] md:w-[500px] mb-16">
                   <h2 className="text-xl">基本プロフィール</h2>
                   <hr className=" border-sub-green mb-6" />

--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -307,7 +307,7 @@ const TennisProfileEdit: NextPage = () => {
         {isAuth && (
           <>
             <div className="container mx-auto">
-              <div className="w-80 md:w-[500px] mx-auto flex flex-col md:justify-center">
+              <div className="w-80 mt-[24px] md:w-[500px] mx-auto flex flex-col md:justify-center md:mt-[48px]">
                 <div className="w-[320px] md:w-[500px] mb-16">
                   <h2 className="text-xl">テニスプロフィール</h2>
                   <hr className=" border-sub-green mb-6" />

--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -97,7 +97,7 @@ const UserProfile: NextPage = () => {
           <>
             {/* <h1>プロフィールページ</h1> */}
             <div className="container mx-auto">
-              <div className="w-80 md:w-[704px] mx-auto flex flex-col md:flex-row md:justify-center">
+              <div className="w-80 mt-6  mx-auto flex flex-col md:flex-row md:justify-center md:mt-[48px] md:w-[704px]">
                 <div className="w-[320px] md:mr-[32px]">
                   <h2 className="text-xl">基本プロフィール</h2>
                   <hr className=" border-sub-green mb-6" />


### PR DESCRIPTION
issue: #38 

**_背景：_**
モーダルを実装した際にheaderに付いていたmarginを削除したため各ページで上部の余白がなくなってレイアウトが崩れてしまっている。

再現手順

- [ ] 各種ページへ遷移
- [ ] 各種ページの上部のmarginが詰まっているのが確認できる

やったこと：

- [ ] user関連ページ、profile、base_profile_efit、tennis_profile_editページのページ上部marginの調整
- [ ] review関連ページ、review一覧、詳細ページ上部のmarginを調整
- [ ] racket関連ページ、ページ上部のmarginの調整。調整の際PrimaryHeadingがアルファベットのところはitaric体に変更
- [ ] racket_image登録ページ、ページ上部のmarginの調整
- [ ] my_equipment関連ページ、ページ上部のmarginを調整。調整の際、一覧、詳細ページのheadingをPrimaryHeadingコンポーネントで書き換えている
- [ ] gut関連ページ、一覧、詳細、登録、更新ページ上部のmarginを調整。調整の際、アルファベットのheadingをitaric体に変更してある
- [ ] gut_image登録ページ、ページ上部のmarginの調整

備考： 
各ページのheadingのmarginで上部の余白を調整している

レビューお願いします
    

    
   