### PR TITLE
modify: tennis_profile編集画面、racket検索モーダル開閉時の位置とスクロールの挙動の修正

### DIFF
--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -44,6 +44,8 @@ const TennisProfileEdit: NextPage = () => {
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
 
   //モーダルの開閉に関するstate
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
+
   const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   useEffect(() => {
@@ -78,6 +80,24 @@ const TennisProfileEdit: NextPage = () => {
     }
   }, [])
 
+  // racket検索モーダル開閉とその時の背景の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (racketSearchModalVisibility) {
+      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [racketSearchModalVisibility])
+
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
       setInputSearchMaker(null);
@@ -89,10 +109,12 @@ const TennisProfileEdit: NextPage = () => {
 
   // ラケット検索モーダルの開閉
   const openRacketSearchModal = () => {
+    setRacketSearchModalVisibility(true);
     setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
+    setRacketSearchModalVisibility(false);
     setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
@@ -467,7 +489,7 @@ const TennisProfileEdit: NextPage = () => {
                 </div>
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen min-h-screen absolute top-[64px] left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto`}>
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
                   <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
                     <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
                       <IoClose size={48} />


### PR DESCRIPTION
_**issue:**_ #91 

_**背景：**_
検索モーダルでモーダルを開いた時に、モーダルの位置とスクロールの位置が適切でなくずれてしまう。また検索結果をページネーション表示させた時に中身の量によってモーダルの高さが小さくなりずれてしまう。加えて、スクロールの挙動がおかしくなっている

_**確認手順：**_

- [ ] userでログインする
- [ ] tennis_profile編集ページに遷移する
- [ ] racekt検索モーダルを表示させる
- [ ] 検索してみる
- [ ] モーダルのスクロールと上位コンポーネントのスクロールが混在しており、背景がスクロールされてしまっているのが確認できる。
- [ ] また、検索後の最終ページなどで表示数が少ないとモーダルの高さが小さくなり背景が見えてしまっているのが確認できる

_**やったこと：**_

- [x] モーダルの開閉状態を扱うstateを用意

- [x] そのstateの状態でuseEffect内でhtmlのタグの<html>と<body>のoverflowの値を切り替えてモーダルの表示時に背景をスクロールさせるかをコントロールするように修正（モーダル開時に背景スクロールを止めるようにuseEffectの部分で実現）
- [x] それに伴うモーダル自体のcssを修正

レビューお願いします