### PR TITLE
modify: pcサイズでのheaderのnavigationリンクの表示の詰まりを調整

### DIFF
--- a/src/components/AdminHeaderNav.tsx
+++ b/src/components/AdminHeaderNav.tsx
@@ -1,0 +1,105 @@
+import { useContext } from "react";
+import DropDownMenu from "./DropDownMenu";
+import HeaderNavLink from "./HeaderNavLink";
+import { AuthContext } from "@/context/AuthContext";
+
+type AdminHeaderNavProps = {
+  logoutHandler: ((e: React.FormEvent<HTMLFormElement>, authType: 'users' | 'admins') => Promise<void>)
+}
+
+const AdminHeaderNav: React.FC<AdminHeaderNavProps> = ({
+  logoutHandler
+}) => {
+  const { admin } = useContext(AuthContext);
+
+  return (
+    <>
+      <HeaderNavLink
+        linkText="dashboard"
+        className="mr-4"
+        href={`/admins/${admin.id}/dashboard`}
+      />
+
+
+      <DropDownMenu
+        dropDownTitle="ストリング"
+        listClassName="mr-4 h-[64px]"
+        dropDownAreaWidth="w-[180px]"
+      >
+        <hr />
+
+        <HeaderNavLink
+          linkText="ストリング一覧"
+          className="p-2"
+          href="/guts"
+        />
+
+        <hr />
+
+        <HeaderNavLink
+          linkText="ストリング登録"
+          className="p-2"
+          href="/guts/register"
+        />
+      </DropDownMenu>
+
+      <DropDownMenu
+        dropDownTitle="ラケット"
+        listClassName="mr-4 h-[64px]"
+        dropDownAreaWidth="w-[180px]"
+      >
+        <hr />
+
+        <HeaderNavLink
+          linkText="ラケット一覧"
+          className="p-2"
+          href="/rackets"
+        />
+
+        <hr />
+
+        <HeaderNavLink
+          linkText="ラケット登録"
+          className="p-2"
+          href="/rackets/register"
+        />
+      </DropDownMenu>
+
+      <DropDownMenu
+        dropDownTitle="画像追加"
+        listClassName="mr-4 h-[64px]"
+        dropDownAreaWidth="w-[180px]"
+      >
+        <hr />
+
+        <HeaderNavLink
+          linkText="ストリング画像追加"
+          className="p-2"
+          href="/gut_images/register"
+        />
+
+        <hr />
+
+        <HeaderNavLink
+          linkText="ラケット画像追加"
+          className="p-2"
+          href="/racket_images/register"
+        />
+      </DropDownMenu>
+
+      <li>
+        <form
+          onSubmit={(e) => logoutHandler(e, 'admins')}
+          className="flex justify-center items-center h-[64px]"
+        >
+          <button
+            type='submit'
+            className="inline-block hover:opacity-80"
+          >ログアウト</button>
+        </form>
+      </li>
+    </>
+  );
+}
+
+export default AdminHeaderNav;

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -1,0 +1,48 @@
+import { ReactNode, useState } from "react";
+
+type DropDownMenuProps = {
+  listClassName: string,
+  dropDownTitle: string,
+  dropDownAreaWidth?: string,
+  children: ReactNode
+}
+
+const DropDownMenu: React.FC<DropDownMenuProps> = ({
+  listClassName,
+  dropDownTitle,
+  dropDownAreaWidth = 'w-[100px]',
+  children
+}) => {
+  const [
+    dropDownMenuVisibilityClassName,
+    setDropDownMenuVisibilityClassName
+  ] = useState<string>('hidden');
+
+
+  const openDropDownMene = () => {
+    setDropDownMenuVisibilityClassName('block');
+  }
+
+  const closeDropDownMene = () => {
+    setDropDownMenuVisibilityClassName('hidden');
+  }
+
+  return (
+    <>
+      <li
+        onMouseOver={openDropDownMene}
+        onMouseOut={closeDropDownMene}
+        className={`flex justify-center items-center relative cursor-pointer ${listClassName}`}
+      >
+        <div className="">{dropDownTitle}</div>
+        <div className={`${dropDownMenuVisibilityClassName} absolute left-0 top-[100%] flex flex-col bg-main-green ${dropDownAreaWidth} text-center mx-auto overflow-x-auto`}>
+          <ul>
+            {children}
+          </ul>
+        </div>
+      </li>
+    </>
+  );
+}
+
+export default DropDownMenu;

--- a/src/components/HeaderNavLink.tsx
+++ b/src/components/HeaderNavLink.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+type HeaderNavLinkProps = {
+  linkText: string
+  className?: string,
+  href: string
+}
+
+const HeaderNavLink: React.FC<HeaderNavLinkProps> = ({
+  linkText,
+  className,
+  href
+}) => {
+  return (
+    <>
+      <li className={`flex justify-center items-center ${className} hover:opacity-80`}>
+        <Link href={href}>{linkText}</Link>
+      </li>
+    </>
+  );
+}
+
+export default HeaderNavLink;

--- a/src/components/UserHeaderNav.tsx
+++ b/src/components/UserHeaderNav.tsx
@@ -1,0 +1,101 @@
+import { useContext } from "react";
+import DropDownMenu from "./DropDownMenu";
+import HeaderNavLink from "./HeaderNavLink";
+import { AuthContext } from "@/context/AuthContext";
+
+type UserHeaderNavProps = {
+  logoutHandler: ((e: React.FormEvent<HTMLFormElement>, authType: 'users' | 'admins') => Promise<void>)
+}
+
+const UserHeaderNav: React.FC<UserHeaderNavProps> = ({
+  logoutHandler
+}) => {
+  const { user } = useContext(AuthContext);
+
+  return (
+    <>
+      <HeaderNavLink
+        linkText="レビュー"
+        className="mr-4"
+        href="/reviews"
+      />
+
+
+      <DropDownMenu
+        dropDownTitle="マイ装備"
+        listClassName="mr-4 h-[64px]"
+        dropDownAreaWidth="w-[180px]"
+      >
+        <hr />
+
+        <HeaderNavLink
+          linkText="マイ装備一覧"
+          className="p-2"
+          href="/my_equipments"
+        />
+
+        <hr />
+
+        <HeaderNavLink
+          linkText="マイ装備追加"
+          className="p-2"
+          href="/my_equipments/register"
+        />
+      </DropDownMenu>
+
+      <HeaderNavLink
+        linkText="ストリング"
+        className="mr-4"
+        href="/guts"
+      />
+
+      <HeaderNavLink
+        linkText="ラケット"
+        className="mr-4"
+        href="/rackets"
+      />
+
+      <DropDownMenu
+        dropDownTitle="画像提供"
+        listClassName="mr-4 h-[64px]"
+        dropDownAreaWidth="w-[180px]"
+      >
+        <hr />
+
+        <HeaderNavLink
+          linkText="ストリング画像提供"
+          className="p-2"
+          href="/gut_images/register"
+        />
+
+        <hr />
+
+        <HeaderNavLink
+          linkText="ラケット画像提供"
+          className="p-2"
+          href="/racket_images/register"
+        />
+      </DropDownMenu>
+
+      <HeaderNavLink
+        linkText="プロフィール"
+        className="mr-4"
+        href={`/users/${user.id}/profile`}
+      />
+
+      <li>
+        <form
+          onSubmit={(e) => logoutHandler(e, 'users')}
+          className="flex justify-center items-center h-[64px]"
+        >
+          <button
+            type='submit'
+            className="inline-block hover:opacity-80"
+          >ログアウト</button>
+        </form>
+      </li>
+    </>
+  );
+}
+
+export default UserHeaderNav;

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import HeaderNavLink from "../HeaderNavLink";
 import UserHeaderNav from "../UserHeaderNav";
+import AdminHeaderNav from "../AdminHeaderNav";
 
 const Header: React.FC = () => {
   const router = useRouter();
@@ -89,27 +90,12 @@ const Header: React.FC = () => {
                   <li><Link href="/users/register">会員登録</Link></li>
                 </>
               )}
-
+              
+              {/* userでログイン中の表示 */}
               {user.id && <UserHeaderNav logoutHandler={logout} />}
-
-              {admin.id && (
-                <>
-                  <li><Link href={`/admins/${admin.id}/dashboard`} className="mr-4">dashboard</Link></li>
-                  <li><Link href={'/guts'} className="mr-4">ストリング</Link></li>
-                  <li><Link href={'/guts/register'} className="mr-4">ストリング登録</Link></li>
-                  <li><Link href={'/gut_images/register'} className="mr-4">ストリング画像提供</Link></li>
-                  <li><Link href={'/rackets'} className="mr-4">ラケット</Link></li>
-                  <li><Link href={'/rackets/register'} className="mr-4">ラケット登録</Link></li>
-                  <li><Link href={'/racket_images/register'} className="mr-4">ラケット画像提供</Link></li>
-
-                  <li>
-                    <form onSubmit={(e) => logout(e, 'admins')} className="inline-block">
-                      <button type='submit' className="inline-block">ログアウト</button>
-                    </form>
-                  </li>
-                </>
-              )}
-
+              
+              {/* adminでログイン中の表示 */}
+              {admin.id && <AdminHeaderNav logoutHandler={logout} />}
             </ul>
           </nav>
         </div>

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -4,6 +4,8 @@ import React, { useContext, useState } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import HeaderNavLink from "../HeaderNavLink";
+import UserHeaderNav from "../UserHeaderNav";
 
 const Header: React.FC = () => {
   const router = useRouter();
@@ -75,8 +77,11 @@ const Header: React.FC = () => {
 
           <nav className="hidden md:block">
             <ul className="flex text-white ">
-
-              <li><Link href="/" className="mr-4">HOME</Link></li>
+              <HeaderNavLink
+                linkText="HOME"
+                className="h-[64] mr-4"
+                href="/"
+              />
 
               {(!user.id && !admin.id) && (
                 <>
@@ -85,24 +90,7 @@ const Header: React.FC = () => {
                 </>
               )}
 
-              {user.id && (
-                <>
-                  <li><Link href={'/reviews'} className="mr-4">レビュー</Link></li>
-                  <li><Link href={'/my_equipments'} className="mr-4">マイ装備</Link></li>
-                  <li><Link href={'/my_equipments/register'} className="mr-4">マイ装備追加</Link></li>
-                  <li><Link href={'/guts'} className="mr-4">ストリング</Link></li>
-                  <li><Link href={'/rackets'} className="mr-4">ラケット</Link></li>
-                  <li><Link href={'/gut_images/register'} className="mr-4">ストリング画像提供</Link></li>
-                  <li><Link href={'/racket_images/register'} className="mr-4">ラケット画像提供</Link></li>
-                  <li><Link href={`/users/${user.id}/profile`} className="mr-4">マイページ</Link></li>
-
-                  <li>
-                    <form onSubmit={(e) => logout(e, 'users')} className="inline-block">
-                      <button type='submit' className="inline-block">ログアウト</button>
-                    </form>
-                  </li>
-                </>
-              )}
+              {user.id && <UserHeaderNav logoutHandler={logout} />}
 
               {admin.id && (
                 <>
@@ -124,7 +112,6 @@ const Header: React.FC = () => {
 
             </ul>
           </nav>
-
         </div>
 
         <div className="md:hidden absolute bottom-[50%] translate-y-2/4 right-4">


### PR DESCRIPTION
_**issue:**_ #47 

_**背景：**_
サイトを作っていく中でheader のnavigation の数ば多くなってきておりpcサイズでnavigationの文字が改行されてレイアウトが崩れてきている。

_**再現手順：**_

- [ ] pcサイズでウィンドウの幅を狭めていく

- [ ] 狭めていくとnavigationのテキストが改行されるなどレイアウトが崩れている

_**やったこと：**_

- [x]  **DropDownMenu、HeaderNavLink**コンポーネントを作成
- [x]  **userログイン中header** の表示をまとめた**UserHeaderNav**コンポーネントをDropDownMenu、HeaderNavLinkを使って作成
- [x] UserHeaderNavコンポーネントをheaderコンポーネントに反映
- [x]  **adminログイン中header** の表示をまとめた**AdminHeaderNav**コンポーネントをDropDownMenu、HeaderNavLinkを使って作成
- [x] AdminHeaderNavコンポーネントをheaderコンポーネントに反映

_**備考：**_
UserHeaderNav、AdminHeaderNavコンポーネントを作成する差異にlogoutに関する部分をコンポーネントに分けた方が良かったが、pull requestを分けたかったため実施しなかった。なので別のissueを立てて実施する予定

レビューお願いします