### PR TITLE
add:#95:gut_review一覧ページにページネーションを追加

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -27,7 +27,7 @@ export type Paginator<T> = {
 
 type PaginationProps = {
   // ページネーションさせたい項目分だけpaginatorの型を増やして使う
-  paginator?: Paginator<Gut> | Paginator<Racket> | Paginator<GutImage> | Paginator<Review>,
+  paginator?: Paginator<Gut> | Paginator<Racket> | Paginator<GutImage>| Paginator<RacketImage> | Paginator<Review>,
   //ページネイトリンクをクリックした時にデータをfetchするための関数が渡ってくる
   paginate: (url?: string) => Promise<void>,
   className?: string

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,5 +1,5 @@
 import type { GutImage } from "@/pages/guts/register";
-import type { Gut } from "@/pages/reviews";
+import type { Gut, Review } from "@/pages/reviews";
 import type { Racket, RacketImage } from "@/pages/users/[id]/profile";
 import React from "react";
 
@@ -27,7 +27,7 @@ export type Paginator<T> = {
 
 type PaginationProps = {
   // ページネーションさせたい項目分だけpaginatorの型を増やして使う
-  paginator?: Paginator<Gut> | Paginator<Racket> | Paginator<GutImage> | Paginator<RacketImage>,
+  paginator?: Paginator<Gut> | Paginator<Racket> | Paginator<GutImage> | Paginator<Review>,
   //ページネイトリンクをクリックした時にデータをfetchするための関数が渡ってくる
   paginate: (url?: string) => Promise<void>,
   className?: string

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -90,13 +90,6 @@ const ReviewList = () => {
   useEffect(() => {
     if (user.id) {
       getReviewsList();
-      // const getAllReviews = async () => {
-      //   await axios.get('api/gut_reviews').then(res => {
-      //     setReviews(res.data);
-      //   })
-      // }
-
-      // getAllReviews();
     } else {
       router.push('/users/login');
     }

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -6,6 +6,7 @@ import AuthCheck from "@/components/AuthCheck";
 import axios from "@/lib/axios";
 import { useRouter } from "next/router";
 import Link from "next/link";
+import Pagination, { Paginator } from "@/components/Pagination";
 
 type GutImage = {
   id: number,
@@ -73,17 +74,29 @@ const ReviewList = () => {
   const [reviews, setReviews] = useState<Review[]>();
   console.log(reviews);
 
+  const [reviewsPaginator, setReviewsPaginator] = useState<Paginator<Review>>();
+
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
+  //ページネーションを考慮したreview一覧データの取得関数
+  const getReviewsList = async (url: string = 'api/gut_reviews') => {
+    await axios.get(url).then(res => {
+      console.log('res', res.data)
+      setReviewsPaginator(res.data)
+      setReviews(res.data.data);
+    })
+  }
+  
   useEffect(() => {
     if (user.id) {
-      const getAllReviews = async () => {
-        await axios.get('api/gut_reviews').then(res => {
-          setReviews(res.data);
-        })
-      }
+      getReviewsList();
+      // const getAllReviews = async () => {
+      //   await axios.get('api/gut_reviews').then(res => {
+      //     setReviews(res.data);
+      //   })
+      // }
 
-      getAllReviews();
+      // getAllReviews();
     } else {
       router.push('/users/login');
     }
@@ -110,6 +123,7 @@ const ReviewList = () => {
                       <>
                         <Link href={`/reviews/${review.id}/review`}>
                           <div key={review.id} className="w-[360px] h-[280px] border border-gray-400 rounded mb-6 flex flex-col justify-around py-4 hover:cursor-pointer">
+                            {/* 単張りのカード */}
                             {review.my_equipment.stringing_way === "single" && (
                               <>
                                 <div className=" flex justify-center mb-8">
@@ -158,6 +172,7 @@ const ReviewList = () => {
                               </>
                             )}
 
+                            {/* ハイブリッド張りのカード */}
                             {review.my_equipment.stringing_way === "hybrid" && (
                               <>
                                 <div className=" flex justify-center mb-8">
@@ -241,6 +256,13 @@ const ReviewList = () => {
                   })
                 )}
               </div>
+
+              {/* ページネーション */}
+              <Pagination
+                paginator={reviewsPaginator}
+                paginate={getReviewsList}
+                className="mt-[32px] md:mt-[48px]"
+              />
             </div>
           </>
         )}


### PR DESCRIPTION
_**issue:**_ #95 

_**背景：**_
一覧表示でページネーション機能がないため、取得データが一ページに表示されてしまっている

_**確認手順：**_

- [ ] userでログインする
- [ ] レビュー一覧画面に遷移する
- [ ] データが一ページに全て表紙されてしまっているのが確認できる

_**やったこと：**_

- [ ] 自作してあったPaginationコンポーネントを使用
- [ ] Paginationコンポーネントに渡すpaginator, paginate のために、reviewsPaginatorのstateを追加、データ取得関数を修正
- [ ] Paginationコンポーネントをgut_reviewで使えるように、Paginationコンポーネントに記載してあった型情報を修正

_**備考：**_
特になし

レビューお願いします。