### PR TITLE
add: マイ装備一覧ページにページネーションを追加

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,5 +1,5 @@
 import type { GutImage } from "@/pages/guts/register";
-import type { Gut, Review } from "@/pages/reviews";
+import type { Gut, MyEquipment, Review } from "@/pages/reviews";
 import type { Racket, RacketImage } from "@/pages/users/[id]/profile";
 import React from "react";
 
@@ -27,7 +27,13 @@ export type Paginator<T> = {
 
 type PaginationProps = {
   // ページネーションさせたい項目分だけpaginatorの型を増やして使う
-  paginator?: Paginator<Gut> | Paginator<Racket> | Paginator<GutImage>| Paginator<RacketImage> | Paginator<Review>,
+  paginator?:
+    | Paginator<Gut>
+    | Paginator<Racket>
+    | Paginator<GutImage>
+    | Paginator<RacketImage>
+    | Paginator<Review>
+    | Paginator<MyEquipment>,
   //ページネイトリンクをクリックした時にデータをfetchするための関数が渡ってくる
   paginate: (url?: string) => Promise<void>,
   className?: string

--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -6,6 +6,7 @@ import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
 import AuthCheck from "@/components/AuthCheck";
 import PrimaryHeading from "@/components/PrimaryHeading";
+import Pagination, { Paginator } from "@/components/Pagination";
 
 const MyEquipmentList = () => {
   const router = useRouter();
@@ -14,17 +15,22 @@ const MyEquipmentList = () => {
 
   const [myEquipments, setMyEquipments] = useState<MyEquipment[]>();
 
+  const [myEquipmentsPaginator, setMyEquipmentsPaginator] = useState<Paginator<MyEquipment>>();
+
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
+  //ページネーションを考慮したmyEquipment一覧データの取得関数
+  const getMyEquipmentListOfUser = async (url: string = `api/my_equipments/user/${user.id}`) => {
+    await axios.get(url).then(res => {
+      console.log('res', res.data)
+      setMyEquipmentsPaginator(res.data)
+      setMyEquipments(res.data.data);
+    })
+  }
+  
   useEffect(() => {
     if (user.id) {
-      const getAllMyEquipmentOfUser = async () => {
-        await axios.get(`api/my_equipments/user/${user.id}`).then(res => {
-          setMyEquipments(res.data);
-        })
-      }
-
-      getAllMyEquipmentOfUser();
+      getMyEquipmentListOfUser();
     } else {
       router.push('/users/login');
     }
@@ -166,6 +172,13 @@ const MyEquipmentList = () => {
                   })
                 )}
               </div>
+
+              {/* ページネーション */}
+              <Pagination
+                paginator={myEquipmentsPaginator}
+                paginate={getMyEquipmentListOfUser}
+                className="mt-[32px] md:mt-[48px]"
+              />
             </div>
           </>
 


### PR DESCRIPTION
_**issue:**_ #98 

_**背景：**_
マイ装備一覧ページにページネーションが無く、取得したデータを一ページで表示してしまっている

_**確認手順：**_

- [ ] userでログインする
- [ ] マイ装備一覧ページに遷移する
- [ ] ページネーションがないことが確認できる

_**やったこと：**_

- [ ] 自作してあったPaginationコンポーネントを使用してページネーションUIを実装
- [ ] PaginationこんんポーネンとのPropsであるpaginator, paginateに渡すstateと関数を定義
- [ ] my_equipmentでPaginationコンポーネントを使用できるようにPagination.tsx に定義してあったpaginator propsの型にPaginator<MyEquipment>を追記

レビューお願いします。

自作してあったPaginationコンポーネントを使用して実装