### PR TITLE
add: gutレビュー一覧、詳細ページの評価グラフをバーグラフで作成

### DIFF
--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useReducer, useState } from "react";
+
+export type EvaluationVal =
+  | 0 | 0.0
+  | 1 | 1.0
+  | 1.5
+  | 2 | 2.0
+  | 2.5
+  | 3 | 3.0
+  | 3.5
+  | 4 | 4.0
+  | 4.5
+  | 5 | 5.0
+
+type BarGraphProps = {
+  areaSize: SizeType,
+  evaluationVal: EvaluationVal,
+  graphHeight: string
+}
+
+type GraphWidth =
+  | "w-[0%]"
+  | "w-[10%]"
+  | "w-[30%]"
+  | "w-[40%]"
+  | "w-[50%]"
+  | "w-[60%]"
+  | "w-[70%]"
+  | "w-[80%]"
+  | "w-[90%]"
+  | "w-[100%]"
+  | undefined;
+
+type graphWidthAction = {
+  type: number,
+  payload?: any
+}
+
+const graphWidthReducer = (
+  state: GraphWidth,
+  { type, payload }: graphWidthAction
+) => {
+  switch (type) {
+    case 0 | 0.0:
+      return 'w-[0%]';
+    case 0.5:
+      return 'w-[10%]';
+    case 1 | 1.0:
+      return 'w-[10%]';
+    case 1.5:
+      return 'w-[30%]';
+    case 2 | 2.0:
+      return 'w-[40%]';
+    case 2.5:
+      return 'w-[50%]';
+    case 3 | 3.0:
+      return 'w-[60%]';
+    case 3.5:
+      return 'w-[70%]';
+    case 4 | 4.0:
+      return 'w-[80%]';
+    case 4.5:
+      return 'w-[90%]';
+    case 5 | 5.0:
+      return 'w-[100%]';
+  }
+}
+
+type SizeType = 'sp' | 'md'
+
+type Size =
+  | 'max-w-[104px]'
+  | 'max-w-[128px]'
+  | undefined;
+
+
+type AreaSizeAction = {
+  type: SizeType,
+  payload?: any
+}
+
+const areaSizeReducer = (
+  state: Size,
+  { type, payload }: AreaSizeAction
+) => {
+  switch (type) {
+    case 'sp':
+      return 'max-w-[104px]';
+    case 'md':
+      return 'max-w-[128px]';
+  }
+}
+
+const BarGraph: React.FC<BarGraphProps> = ({
+  areaSize = 'sp',
+  evaluationVal,
+  graphHeight
+}) => {
+  const [areaSizeClassName, areaSizeClassNameDispatch] = useReducer(areaSizeReducer, 'max-w-[104px]')
+
+  const [graphWidthClassName, graphWidthClassNameDispatch] = useReducer(graphWidthReducer, 'w-[0%]');
+
+  useEffect(() => {
+    graphWidthClassNameDispatch({ type: evaluationVal })
+    areaSizeClassNameDispatch({ type: areaSize })
+  }, [])
+
+  return (
+    <>
+      <div className={`relative w-[100%] ${areaSizeClassName} ${graphHeight}`}>
+        {/* bar area */}
+        <div className={`w-[100%] ${areaSizeClassName} ${graphHeight} bg-gray-200 absolute top-0 left-0 z-0`}>
+          <span></span>
+        </div>
+
+        {/* 可変　bar */}
+        <div className={`${graphWidthClassName} ${areaSizeClassName} ${graphHeight} bg-sub-green absolute top-0 left-0 z-20`}>
+          <span></span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default BarGraph;

--- a/src/pages/reviews/[id]/review.tsx
+++ b/src/pages/reviews/[id]/review.tsx
@@ -1,3 +1,4 @@
+import BarGraph, { EvaluationVal } from "@/components/BarGraph";
 import type { Review } from "..";
 import AuthCheck from "@/components/AuthCheck"
 import { AuthContext } from "@/context/AuthContext";
@@ -129,20 +130,56 @@ const Review = () => {
                   <hr className="w-[360px] border-t-sub-green md:hidden" />
                 </div>
 
-
                 {/* 評価値 */}
                 {/* <div className="w-[320px] mb-6"> */}
-                <div className="md:flex ">
-                  <div className="mb-6 md:w-[320px] md:mr-[32px] md:mb-0 md:pt-[24px]">
-                    <ReviewBarGraph title="自分に合っているか" data={review?.match_rate} />
-                    <ReviewBarGraph title="切れにくさ" data={review?.pysical_durability} />
-                    <ReviewBarGraph title="打球感の持続力" data={review?.performance_durability} />
+                <div className="w-[320px] md:flex md:justify-between md:w-[768px] ">
+                  <div className="mb-6 w-[320px] md:w-[360px]  md:mb-0 md:pt-[24px]">
+                    <div className="flex justify-end mb-2">
+                      <span className="text-[14px] h-[16px] leading-[16px] pr-1 md:text-[16px] md:h-[18px] md:leading-[18px]">自分に合っているか</span>
+                      {review && (
+                          <BarGraph
+                            evaluationVal={review.match_rate as EvaluationVal}
+                            areaSize="md"
+                            graphHeight="h-[16px] md:h-[18px]"
+                          />
+                      )}
+                      <span className="inline-block border-r-2 border-sub-green ml-2 mr-1"></span>
+                      <span className="inline-block text-[14px] text-center h-[16px] w-6 leading-[16px] md:text-[16px] md:h-[18px] md:leading-[18px]">{review?.match_rate}</span>
+                    </div>
+
+                    <div className="flex justify-end mb-2">
+                      <span className="text-[14px] h-[16px] leading-[16px] pr-1 md:text-[16px] md:h-[18px] md:leading-[18px]">切れにくさ</span>
+                      {review && (
+                          <BarGraph
+                            evaluationVal={review.pysical_durability as EvaluationVal}
+                            areaSize="md"
+                            graphHeight="h-[16px] md:h-[18px]"
+                          />
+                      )}
+                      <span className="inline-block border-r-2 border-sub-green ml-2 mr-1"></span>
+                      <span className="inline-block text-[14px] text-center h-[16px] w-6 leading-[16px] md:text-[16px] md:h-[18px] md:leading-[18px]">{review?.pysical_durability}</span>
+                    </div>
+
+                    <div className="flex justify-end mb-2">
+                      <span className="text-[14px] h-[16px] leading-[16px] pr-1 md:text-[16px] md:h-[18px] md:leading-[18px]">打球感の持続力</span>
+                      {review && (
+                          <BarGraph
+                            evaluationVal={review.performance_durability as EvaluationVal}
+                            areaSize="md"
+                            graphHeight="h-[16px] md:h-[18px]"
+                          />
+                      )}
+                      <span className="inline-block border-r-2 border-sub-green ml-2 mr-1"></span>
+                      <span className="inline-block text-[14px] text-center h-[16px] w-6 leading-[16px] md:text-[16px] md:h-[18px] md:leading-[18px]">{review?.performance_durability}</span>
+                    </div>
+
+                    <p className="text-[14px] text-gray-500 text-end">max 5.0</p>
                   </div>
 
                   {/* レビューコメント */}
                   <div className="mb-10">
                     <span className="block">レビュー</span>
-                    <p className="border min-h-[120px] w-[280px] p-1 md:w-[400px]">{review?.review}</p>
+                    <p className="border min-h-[120px] w-[320px] p-1 md:w-[360px]">{review?.review}</p>
                   </div>
 
                 </div>
@@ -155,17 +192,6 @@ const Review = () => {
         )}
       </AuthCheck>
     </>
-  );
-}
-
-export const ReviewBarGraph = ({ title, data }: { title: string, data?: number }) => {
-  return (
-    <div className="flex justify-end mb-2">
-      <span className="text-[14px] pr-1 md:text-[16px]">{title}</span>
-      <span className="inline-block w-[104px] h-[20px] border mr-2 md:h-[24px] md:w-[120px]"></span>
-      <span className="inline-block border-r-2 border-sub-green mr-1"></span>
-      <span className="inline-block text-[14px] w-4 md:text-[16px]">{data}</span>
-    </div>
   );
 }
 

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -7,6 +7,7 @@ import axios from "@/lib/axios";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import Pagination, { Paginator } from "@/components/Pagination";
+import BarGraph, { EvaluationVal } from "@/components/BarGraph";
 
 type GutImage = {
   id: number,
@@ -86,7 +87,7 @@ const ReviewList = () => {
       setReviews(res.data.data);
     })
   }
-  
+
   useEffect(() => {
     if (user.id) {
       getReviewsList();
@@ -238,9 +239,15 @@ const ReviewList = () => {
                             <hr className="w-[320px] border-sub-green mb-2 mx-auto" />
                             <div className="flex justify-end mr-6">
                               <span className="text-[10px] pr-1">自分に合っているか</span>
-                              <span className="inline-block w-[104px] h-4 border mr-2"></span>
-                              <span className="inline-block border-r-2 border-sub-green mr-1"></span>
-                              <span className="text-[10px]">4.5</span>
+
+                              <BarGraph
+                                evaluationVal={review.match_rate as EvaluationVal}
+                                areaSize="sp"
+                                graphHeight="h-[16px] md:h-[18px]"
+                              />
+
+                              <span className="inline-block border-r-2 border-sub-green mr-1 ml-2"></span>
+                              <span className="text-[10px]">{review.match_rate}</span>
                             </div>
                           </div>
                         </Link>


### PR DESCRIPTION
_**issue:**_ #100 

_**背景：**_
現状は評価グラフが仮の要素として作成されており機能していない。

_**確認手順：**_

- [ ] userでログインする
- [ ] gutレビュー一覧ページに遷移する
- [ ] 評価グラフが仮の要素であるのが確認できる
- [ ] 次にレビューのどれかをクリックして詳細ページに遷移する
- [ ] レビュー詳細ページでも同じく、評価グラフが仮の要素であるのが確認できる

_**やったこと：**_

- [ ] BarGraphコンポーネントを作成
- [ ] gutレビュー一覧ページのカード内のグラフをBarGraphコンポーネントで置き換え
- [ ] gutレビュー詳細ページの評価グラフをBarGraphコンポーネントで置き換え、それに伴うｃｓｓを微修正

_**備考：**_
tailwindを使って**w-[ ]のような任意の値**を指定するとき、**[ ]内を動的に生成**するとtailwindの仕様のせいでスタイルがうまく反映されなかったので、少し手こずった。
解決策として、useReducerを使ってtypeを識別しとして**当てたいstyleを元々の文字列として扱う**ことで、うまく反映させることができた。
実装方として、もっと良い方法があったかもしれない

レビューお願いします

