### PR TITLE
add: gutレビュー投稿ページの作成

### DIFF
--- a/src/components/EvaluationRangeItem.tsx
+++ b/src/components/EvaluationRangeItem.tsx
@@ -1,0 +1,51 @@
+import InputRange from "./inputRange";
+
+type EvaluationRangeItemProps = {
+  labelText: string,
+  scale: boolean,
+  onChangeInputRangeHnadler: (e: React.ChangeEvent<HTMLInputElement>) => void
+  valueState?: number | null,
+  className?: string
+}
+
+const EvaluationRangeItem: React.FC<EvaluationRangeItemProps> = ({
+  labelText,
+  scale = false,
+  onChangeInputRangeHnadler,
+  valueState,
+  className
+}) => {
+  return (
+    <>
+      <div className={`flex flex-col ${className}`}>
+        <p className="flex justify-between mb-[8px]">
+          <label className="text-[14px] md:text-[16px]">{labelText}</label>
+          {valueState && <span className="text-[14px] mr-2 italic md:text-[16px]">{valueState.toFixed(1)}</span>}
+        </p>
+
+        <InputRange
+          min={1}
+          max={5}
+          step={0.5}
+          value={3}
+          chengeHandler={onChangeInputRangeHnadler}
+        />
+
+        {scale && (
+          <>
+            {/* メモリ */}
+            <div className="flex justify-between mt-2">
+              <span className="inline-block text-[14px] text-center italic w-[20px] h-[16px] leading-[16px]">1</span>
+              <span className="inline-block text-[14px] text-center italic w-[20px] h-[16px] leading-[16px]">2</span>
+              <span className="inline-block text-[14px] text-center italic w-[20px] h-[16px] leading-[16px]">3</span>
+              <span className="inline-block text-[14px] text-center italic w-[20px] h-[16px] leading-[16px]">4</span>
+              <span className="inline-block text-[14px] text-center italic w-[20px] h-[16px] leading-[16px]">5</span>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default EvaluationRangeItem;

--- a/src/components/MyEquipmentCard.tsx
+++ b/src/components/MyEquipmentCard.tsx
@@ -2,7 +2,7 @@ import { MyEquipment } from "@/pages/reviews";
 
 type MyEquipmentCardProps = {
   myEquipment: MyEquipment
-  clickHandler?: () => {}
+  clickHandler?: any
 }
 
 const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({

--- a/src/components/MyEquipmentCard.tsx
+++ b/src/components/MyEquipmentCard.tsx
@@ -1,0 +1,136 @@
+import { MyEquipment } from "@/pages/reviews";
+
+type MyEquipmentCardProps = {
+  myEquipment: MyEquipment
+  clickHandler?: () => {}
+}
+
+const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({
+  myEquipment,
+  clickHandler
+}) => {
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/';
+
+  return (
+    <>
+      <div
+        onClick={clickHandler}
+        className="max-w-[360px] w-[100%] min-h-[280px] bg-white border border-gray-400 rounded-lg flex flex-col justify-around py-4 hover:cursor-pointer"
+      >
+        {/* 単張りの時の表示 */}
+        {myEquipment.stringing_way === "single" && (
+          <>
+            <div className=" flex justify-center mb-6">
+              {/* gut情報 */}
+              <div className="mr-8">
+                <div className="w-[96px] flex flex-col justify-start items-start">
+                  <div className="w-[96px] mb-1">
+                    {myEquipment.main_gut.gut_image.file_path
+                      && <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
+                    }
+                  </div>
+
+                  <div className="mb-2">
+                    <p className="text-[14px] h-[16px] mb-2">{myEquipment.main_gut.maker.name_ja}</p>
+                    <p className="tracking-tighter min-h-[16px] text-[14px]">{myEquipment.main_gut.name_ja}</p>
+                  </div>
+
+                  <div>
+                    <p className="tracking-tighter h-[14px] text-[12px] mr-auto mb-2">{myEquipment.main_gut_guage.toFixed(2)} / {myEquipment.cross_gut_guage.toFixed(2)} mm</p>
+                    <p className="tracking-tighter h-[14px] text-[12px] mr-auto">{myEquipment.main_gut_tension} / {myEquipment.cross_gut_tension} ポンド</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* racket情報 */}
+              <div className="flex flex-col items-center w-[96px]">
+                <div className="w-[72px] flex flex-col items-center mb-1">
+                  {myEquipment.racket.racket_image.file_path
+                    ? <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[72px] h-[96px]" />
+                    : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[72px] h-[96px]" />
+                  }
+                </div>
+
+                <div className="text-center">
+                  <p className="h-[16px] text-[14px] mb-4">{myEquipment.racket.maker.name_ja}</p>
+                  <p className="tracking-tighter break-words min-h-[16px] text-[14px] max-w-[92px] ">{myEquipment.racket.name_ja}</p>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ハイブリッド張りの時の表示 */}
+        {myEquipment.stringing_way === "hybrid" && (
+          <>
+            <div className=" flex justify-center gap-x-[20px] mb-6">
+              <div className="">
+                <div className="w-[96px] flex flex-col justify-start items-start ">
+                  <div className="w-[96px] mb-1">
+                    {myEquipment.main_gut.gut_image.file_path
+                      && <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
+                    }
+                  </div>
+
+                  <div className="mb-2">
+                    <p className="text-[14px] h-[16px] mb-2">{myEquipment.main_gut.maker.name_ja}</p>
+                    <p className="tracking-tighter min-h-[16px] text-[14px] ">{myEquipment.main_gut.name_ja}</p>
+                  </div>
+
+                  <div>
+                    <p className="tracking-tighter h-[14px] text-[12px] mr-auto mb-2">{myEquipment.main_gut_guage.toFixed(2)} mm</p>
+                    <p className="tracking-tighter h-[14px] text-[12px] mr-auto">{myEquipment.main_gut_tension} ポンド</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="">
+                <div className="w-[96px] flex flex-col justify-start items-start">
+                  <div className="w-[96px] mb-1">
+                    {myEquipment.cross_gut.gut_image.file_path
+                      && <img src={`${baseImagePath}${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
+                    }
+                  </div>
+
+                  <div className="mb-2">
+                    <p className="h-[16px] text-[14px] mb-2">{myEquipment.cross_gut.maker.name_ja}</p>
+                    <p className="tracking-tighter min-h-[16px] text-[14px] ">{myEquipment.cross_gut.name_ja}</p>
+                  </div>
+
+                  <div>
+                    <p className="tracking-tighter h-[14px] text-[12px] mr-auto mb-2">{myEquipment.cross_gut_guage.toFixed(2)} mm</p>
+                    <p className="tracking-tighter h-[14px] text-[12px] mr-auto">{myEquipment.cross_gut_tension} ポンド</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* racket情報 */}
+              <div className="flex flex-col items-center w-[96px]">
+                <div className="w-[72px] flex flex-col items-center mb-1">
+                  {myEquipment.racket.racket_image.file_path
+                    ? <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[72px] h-[96px]" />
+                    : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[72px] h-[96px]" />
+                  }
+                </div>
+
+                <div className="text-center">
+                  <p className="h-[16px] text-[14px] mb-4">{myEquipment.racket.maker.name_ja}</p>
+                  <p className="tracking-tighter break-words min-h-[16px] text-[14px] max-w-[92px] ">{myEquipment.racket.name_ja}</p>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        <hr className="w-[328px] border-sub-green mb-2 mx-auto" />
+
+        <div className="flex flex-col items-end mr-[24px]">
+          <span className="inline-block h-[16px] text-[14px] mb-2">張った日：{myEquipment.new_gut_date}</span>
+          <span className="inline-block h-[16px] text-[14px] ">張り替え・ストリングが切れた日：{myEquipment.change_gut_date}</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default MyEquipmentCard;

--- a/src/components/UserHeaderNav.tsx
+++ b/src/components/UserHeaderNav.tsx
@@ -14,12 +14,27 @@ const UserHeaderNav: React.FC<UserHeaderNavProps> = ({
 
   return (
     <>
-      <HeaderNavLink
-        linkText="レビュー"
-        className="mr-4"
-        href="/reviews"
-      />
+      <DropDownMenu
+        dropDownTitle="レビュー"
+        listClassName="pr-4 h-[64px]"
+        dropDownAreaWidth="w-[160px]"
+      >
+        <hr />
 
+        <HeaderNavLink
+          linkText="投稿一覧"
+          className="p-2"
+          href="/reviews"
+        />
+
+        <hr />
+
+        <HeaderNavLink
+          linkText="レビュー投稿"
+          className="p-2"
+          href="/reviews/register"
+        />
+      </DropDownMenu>
 
       <DropDownMenu
         dropDownTitle="マイ装備"

--- a/src/components/inputRange.tsx
+++ b/src/components/inputRange.tsx
@@ -1,0 +1,62 @@
+type InputRangeProps = {
+  min: number,
+  max: number,
+  step: number,
+  value: number,
+  chengeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+const InputRange: React.FC<InputRangeProps> = ({
+  min,
+  max,
+  step,
+  value,
+  chengeHandler
+}) => {
+  return (
+    <>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        defaultValue={value}
+        onChange={chengeHandler}
+        className={`
+          w-full bg-transparent cursor-pointer appearance-none disabled:opacity-50 disabled:pointer-events-none focus:outline-none
+          [&::-webkit-slider-thumb]:w-[20px]
+          [&::-webkit-slider-thumb]:h-[20px]
+          [&::-webkit-slider-thumb]:appearance-none
+          [&::-webkit-slider-thumb]:rounded-full
+          [&::-webkit-slider-thumb]:shadow-[0_0_0_1px_#628B5B]
+          [&::-webkit-slider-thumb]:bg-sub-green
+          [&::-webkit-slider-thumb]:relative
+          [&::-webkit-slider-thumb]:top-[-50%]
+
+          [&::-moz-range-thumb]:w-[20px]
+          [&::-moz-range-thumb]:h-[20px]
+          [&::-moz-range-thumb]:appearance-none
+          [&::-moz-range-thumb]:rounded-full
+          [&::-moz-range-thumb]:shadow-[0_0_0_1px_#628B5B]
+          [&::-moz-range-thumb]:bg-sub-green
+          [&::-moz-range-thumb]:relative
+          [&::-moz-range-thumb]:top-[-50%]
+
+          [&::-webkit-slider-runnable-track]:w-full
+          [&::-webkit-slider-runnable-track]:h-[10px]
+          [&::-webkit-slider-runnable-track]:border-black
+          [&::-webkit-slider-runnable-track]:rounded-full
+          [&::-webkit-slider-runnable-track]:bg-gray-300
+
+          [&::-moz-range-track]:w-full
+          [&::-moz-range-track]:h-[10px]
+          [&::-moz-range-track]:border-black
+          [&::-moz-range-track]:rounded-full
+          [&::-moz-range-track]:bg-gray-300
+        `}
+      />
+    </>
+  );
+}
+
+export default InputRange;

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -128,7 +128,8 @@ const Header: React.FC = () => {
 
               {user.id && (
                 <>
-                  <li><Link href={'/reviews'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">レビュー</Link></li>
+                  <li><Link href={'/reviews'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">レビュー一覧</Link></li>
+                  <li><Link href={'/reviews/register'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">レビュー投稿</Link></li>
                   <li><Link href={'/my_equipments'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">マイ装備</Link></li>
                   <li><Link href={'/my_equipments/register'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">マイ装備追加</Link></li>
                   <li><Link href={'/guts'} className="inline-block text-center h-12 leading-[48px] border-b-2 border-b-afaint-green  w-full">ストリング</Link></li>

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -57,6 +57,7 @@ export type MyEquipment = {
 
 export type Review = {
   id: number,
+  user_id: number,
   equipment_id: number,
   match_rate: number,
   pysical_durability: number,

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -1,0 +1,11 @@
+import { NextPage } from "next";
+
+const GutReviewRegister: NextPage = () => {
+  return (
+    <>
+      <h1>ストリングレビュー登録画面</h1>
+    </>
+  );
+}
+
+export default GutReviewRegister;

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -15,6 +15,7 @@ import SubHeading from "@/components/SubHeading";
 import TextUnderBar from "@/components/TextUnderBar";
 import { IoClose } from "react-icons/io5";
 import Pagination, { Paginator } from "@/components/Pagination";
+import EvaluationRangeItem from "@/components/EvaluationRangeItem";
 import { getToday } from "@/modules/getToday";
 
 const GutReviewRegister: NextPage = () => {
@@ -76,6 +77,14 @@ const GutReviewRegister: NextPage = () => {
   const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
 
   const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
+
+  // 評価に関するstate
+  const [matchRate, setMatchRate] = useState<number>(3);
+  console.log('matchRate', matchRate)
+  const [pysicalDurability, setPysicalDurability] = useState<number>(3);
+  console.log('pysicalDurability', pysicalDurability)
+  const [performanceDurability, setPerformanceDurability] = useState<number>(3);
+  console.log('performanceDurability', performanceDurability)
 
   useEffect(() => {
     const getMakerList = async () => {
@@ -342,7 +351,7 @@ const GutReviewRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
-            <div className="container mx-auto">
+            <div className="container mx-auto mb-6">
               <div className="text-center my-6 md:mb-[32px]">
                 <PrimaryHeading text="Post Review" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
@@ -617,27 +626,63 @@ const GutReviewRegister: NextPage = () => {
 
                   {/* section-two */}
                   <div className="md:w-[100%] md:max-w-[360px]">
+                    <div className="w-[100%] max-w-[320px] mb-6 md:max-w-[360px]">
+                      <SubHeading text='評価' className="text-[16px] md:text-[18px] md:mb-2" />
+                      <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                    </div>
 
-                    {/* <div className="mb-[48px] md:flex md:flex-col md:mb-[64px]">
-                      <label htmlFor="comment">コメント</label>
-                      <textarea
-                        name="comment"
-                        id="comment"
-                        onChange={(e) => setComment(e.target.value)}
-                        className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
+                    <div>
+                      <EvaluationRangeItem
+                        labelText="自分に合っているか"
+                        scale={true}
+                        onChangeInputRangeHnadler={(e) => { setMatchRate(Number(e.target.value)) }}
+                        valueState={matchRate}
+                        className="mb-6 md:mb-2"
+                      />
+                      
+                      <EvaluationRangeItem
+                        labelText="切れにくさ"
+                        scale={false}
+                        onChangeInputRangeHnadler={(e) => { setPysicalDurability(Number(e.target.value)) }}
+                        valueState={pysicalDurability}
+                        className="mb-[41px] md:mb-[36px]"
                       />
 
-                      {errors.comment.length !== 0 &&
-                        errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      }
-                    </div> */}
+                      <EvaluationRangeItem
+                        labelText="打球感の持続"
+                        scale={false}
+                        onChangeInputRangeHnadler={(e) => { setPerformanceDurability(Number(e.target.value)) }}
+                        valueState={performanceDurability}
+                        className="mb-10"
+                      />
 
-                    {/* <div className="flex justify-center md:justify-end">
+                      <div className="mb-[16px] md:flex md:flex-col">
+                        <label
+                          htmlFor="comment"
+                          className="text-[14px] md:text-[16px] mb-1 md:mb-2"
+                        >コメント</label>
+
+                        <textarea
+                          name="comment"
+                          id="comment"
+                          onChange={(e) => setComment(e.target.value)}
+                          className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
+                        />
+
+                        {errors.comment.length !== 0 &&
+                          errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+                    </div>
+
+                    <p className="text-[14px] md:text-[16px] mb-6 md:mb-4 md:mb-4">※ 装備構成を直接入力した場合は、その構成のマイ装備も作成されます</p>
+
+                    <div className="flex justify-center md:justify-end">
                       <button
                         type="submit"
                         className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
-                      >追加する</button>
-                    </div> */}
+                      >投稿する</button>
+                    </div>
                   </div>
 
                 </form>

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -27,7 +27,7 @@ type PostingGutReviewData = {
   review: string,
   equipment_id: number | null,
   need_creating_my_equipment: boolean,
-  
+
   user_id?: number,
   user_height?: Height,
   user_age?: Age,
@@ -379,8 +379,9 @@ const GutReviewRegister: NextPage = () => {
     cross_gut_tension: string[],
     racket_id: string[],
     new_gut_date: string[],
-    change_gut_date: string[],
-    comment: string[],
+    // change_gut_date: string[],
+    // comment: string[],
+    review: string[]
   }
 
   const initialErrorVals = {
@@ -397,8 +398,9 @@ const GutReviewRegister: NextPage = () => {
     cross_gut_tension: [],
     racket_id: [],
     new_gut_date: [],
-    change_gut_date: [],
-    comment: [],
+    // change_gut_date: [],
+    // comment: [],
+    review: [],
   }
 
   const [errors, setErrors] = useState<Errors>(initialErrorVals);
@@ -419,7 +421,7 @@ const GutReviewRegister: NextPage = () => {
     }
 
     // 新規でmyEquipmentの登録が必要な場合にpostingDataに必要項目を追加
-    if(!myEquipment) {
+    if (!myEquipment) {
       postingData.user_id = user.id;
       postingData.user_height = userTennisProfile?.height;
       postingData.user_age = userTennisProfile?.age;
@@ -433,10 +435,10 @@ const GutReviewRegister: NextPage = () => {
       postingData.cross_gut_tension = inputMainCrossTension;
       postingData.racket_id = racket?.id;
       postingData.new_gut_date = inputNewGutDate;
-      postingData.change_gut_date =  null;
+      postingData.change_gut_date = null;
       postingData.comment = '';
     }
-    
+
     console.log('postingData', postingData)
 
     await csrf();
@@ -763,19 +765,19 @@ const GutReviewRegister: NextPage = () => {
 
                       <div className="mb-[16px] md:flex md:flex-col">
                         <label
-                          htmlFor="comment"
+                          htmlFor="review"
                           className="text-[14px] md:text-[16px] mb-1 md:mb-2"
                         >コメント</label>
 
                         <textarea
-                          name="comment"
-                          id="comment"
+                          name="review"
+                          id="review"
                           onChange={(e) => setReviewComment(e.target.value)}
                           className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
                         />
 
-                        {errors.comment.length !== 0 &&
-                          errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        {errors.review.length !== 0 &&
+                          errors.review.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                         }
                       </div>
                     </div>
@@ -788,6 +790,18 @@ const GutReviewRegister: NextPage = () => {
                         className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
                       >投稿する</button>
                     </div>
+                    {errors.main_gut_id.length !== 0 &&
+                      errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.cross_gut_id.length !== 0 &&
+                      errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.racket_id.length !== 0 &&
+                      errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.review.length !== 0 &&
+                      errors.review.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
                   </div>
 
                 </form>

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -344,7 +344,7 @@ const GutReviewRegister: NextPage = () => {
           <>
             <div className="container mx-auto">
               <div className="text-center my-6 md:mb-[32px]">
-                <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+                <PrimaryHeading text="Post Review" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
               <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
@@ -356,11 +356,22 @@ const GutReviewRegister: NextPage = () => {
 
                   {/* //section-one */}
                   <div className="md:w-[100%] md:max-w-[360px]">
+                    <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                      <SubHeading text='装備構成' className="text-[16px] md:text-[18px] md:mb-2" />
+                      <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                    </div>
+
+                    <div className="flex justify-end">
+                      {/* <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">マイ装備から選択</button> */}
+                      <button type="button" className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">マイ装備から選択</button>
+                      {/* <button type="button" className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">リセット</button> */}
+                    </div>
+
                     {/* ストリング関連 */}
                     <div>
                       <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
                         <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
-                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                        <TextUnderBar className="w-[100%] max-w-[84px] md:max-w-[96px]" />
                       </div>
 
                       {/* 張り方選択 */}
@@ -530,7 +541,7 @@ const GutReviewRegister: NextPage = () => {
                       </div>
 
                       {/* gutを新調日 */}
-                      <div className=" mb-6">
+                      {/* <div className=" mb-6">
                         <div className="flex flex-col">
                           <label htmlFor="new_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張った日</label>
                           <input
@@ -546,10 +557,10 @@ const GutReviewRegister: NextPage = () => {
                         {errors.new_gut_date.length !== 0 &&
                           errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                         }
-                      </div>
+                      </div> */}
 
                       {/* gut交換日 */}
-                      <div className="mb-[40px]">
+                      {/* <div className="mb-[40px]">
                         <div className="flex flex-col">
                           <label htmlFor="change_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張り替え・ストリングが切れた日</label>
                           <input
@@ -564,17 +575,14 @@ const GutReviewRegister: NextPage = () => {
                         {errors.change_gut_date.length !== 0 &&
                           errors.change_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                         }
-                      </div>
+                      </div> */}
                     </div>
-                  </div>
 
-                  {/* section-two */}
-                  <div className="md:w-[100%] md:max-w-[360px]">
                     {/* ラケット関連 */}
                     <div className="mb-[40px]">
                       <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
                         <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
-                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                        <TextUnderBar className="w-[100%] max-w-[64px] md:max-w-[72px]" />
                       </div>
 
                       <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ラケット</p>
@@ -605,8 +613,12 @@ const GutReviewRegister: NextPage = () => {
                         errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       }
                     </div>
+                  </div>
 
-                    <div className="mb-[48px] md:flex md:flex-col md:mb-[64px]">
+                  {/* section-two */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+
+                    {/* <div className="mb-[48px] md:flex md:flex-col md:mb-[64px]">
                       <label htmlFor="comment">コメント</label>
                       <textarea
                         name="comment"
@@ -618,14 +630,14 @@ const GutReviewRegister: NextPage = () => {
                       {errors.comment.length !== 0 &&
                         errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                       }
-                    </div>
+                    </div> */}
 
-                    <div className="flex justify-center md:justify-end">
+                    {/* <div className="flex justify-center md:justify-end">
                       <button
                         type="submit"
                         className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
                       >追加する</button>
-                    </div>
+                    </div> */}
                   </div>
 
                 </form>

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -1,11 +1,768 @@
-import { NextPage } from "next";
+import type { NextPage } from "next";
+import type { Maker, Racket, TennisProfile } from "../users/[id]/profile";
+import type { Gut } from "../reviews";
+
+import axios from "@/lib/axios";
+import Cookies from "js-cookie";
+
+import React, { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
+import SubHeading from "@/components/SubHeading";
+import TextUnderBar from "@/components/TextUnderBar";
+import { IoClose } from "react-icons/io5";
+import Pagination, { Paginator } from "@/components/Pagination";
+import { getToday } from "@/modules/getToday";
 
 const GutReviewRegister: NextPage = () => {
+  const router = useRouter();
+
+  const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
+
+  const today: string = getToday();
+
+  const [userTennisProfile, setUserTennisProfile] = useState<TennisProfile>();
+
+  //my_equipmentの登録に使うstate群
+  const [stringingWay, setStringingWay] = useState<string>('single');
+
+  const [mainGut, setMainGut] = useState<Gut>();
+
+  const [crossGut, setCrossGut] = useState<Gut>();
+
+  const [racket, setRacket] = useState<Racket>();
+
+  //要素の表示などに使用するstate群
+  const [makers, setMakers] = useState<Maker[]>();
+
+  const [witchSelectingGut, setWitchSelectingGut] = useState<string>('');
+
+  // inputに関するstate
+  const [inputMainGutGuage, setInputMainGutGuage] = useState<number>(1.25);
+
+  const [inputCrossGutGuage, setInputCrossGutGuage] = useState<number>(1.25);
+
+  const [inputMainGutTension, setInputMainGutTension] = useState<number>(50);
+
+  const [inputMainCrossTension, setInputMainCrossTension] = useState<number>(50);
+
+  const [inputNewGutDate, setInputNewGutDate] = useState<string>(today);
+
+  const [inputChangeGutDate, setInputChangeGutDate] = useState<string>();
+
+  const [comment, setComment] = useState<string>('');
+
+  //モーダルの開閉に関するstate
+  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
+
+  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
+
+  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  //検索関連のstate
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+
+  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+
+  const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
+
+  const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
+
+  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
+
+  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
+
+  useEffect(() => {
+    const getMakerList = async () => {
+      await axios.get('api/makers').then(res => {
+        setMakers(res.data);
+      })
+    }
+
+    const getUserTennisProfile = async () => {
+      await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
+        setUserTennisProfile(res.data);
+      })
+    }
+
+    getUserTennisProfile();
+    getMakerList();
+  }, [])
+
+  // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (modalVisibility) {
+      setModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [modalVisibility])
+
+  // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (racketSearchModalVisibility) {
+      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [racketSearchModalVisibility])
+
+  //inputの制御関数群
+  const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setStringingWay(e.target.value);
+    setCrossGut(undefined);
+  }
+
+  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setInputSearchMaker(null);
+      return
+    };
+
+    setInputSearchMaker(Number(e.target.value));
+  }
+
+  const onChangeInputNewGutDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const todayRegex: RegExp = /\d{4}-\d{2}-\d{2}$/;
+
+    if (todayRegex.test(e.target.value)) {
+      setInputNewGutDate(e.target.value);
+    }
+  }
+
+  const onChangeInputChangeGutDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const todayRegex: RegExp = /\d{4}-\d{2}-\d{2}$/;
+
+    if (todayRegex.test(e.target.value)) {
+      setInputChangeGutDate(e.target.value);
+    }
+  }
+
+  //モーダルの開閉
+  const closeModal = () => {
+    setModalVisibility(false);
+    setModalVisibilityClassName('opacity-0 scale-0')
+    setWitchSelectingGut('');
+  }
+
+  const openModal = () => {
+    setModalVisibilityClassName('opacity-100 scale-100')
+  }
+
+  //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
+  const openMainGutSearchModal = () => {
+    setModalVisibility(true);
+    openModal();
+    setWitchSelectingGut('main');
+  }
+
+  const openCrossGutSearchModal = () => {
+    setModalVisibility(true);
+    openModal();
+    setWitchSelectingGut('cross');
+  }
+
+  //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
+  const openRacketSearchModal = () => {
+    setRacketSearchModalVisibility(true);
+    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
+  }
+
+  const closeRacketSearchModal = () => {
+    setRacketSearchModalVisibility(false)
+    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+  }
+
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
+
+  //ページネーションを考慮した検索後racket一覧データの取得関数
+  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
+    await axios.get(url).then((res) => {
+      setGutsPaginator(res.data);
+
+      setSearchedGuts(res.data.data);
+    })
+  }
+
+  //gut検索
+  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      getSearchedGutsList();
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  //ページネーションを考慮した検索後racket一覧データの取得関数
+  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
+    await axios.get(url).then((res) => {
+      setRacketsPaginator(res.data);
+
+      setSearchedRackets(res.data.data);
+    })
+  }
+
+  //racket検索
+  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      getSearchedRacketsList();
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  const selectGut = (gut: Gut) => {
+    if (witchSelectingGut === 'main') {
+      setMainGut(gut);
+    } else if (witchSelectingGut === 'cross') {
+      setCrossGut(gut);
+    }
+
+    closeModal();
+  }
+  const selectRacket = (racket: Racket) => {
+    setRacket(racket)
+    closeRacketSearchModal();
+  }
+
+  type Errors = {
+    user_id: string[],
+    user_height: string[],
+    user_age: string[],
+    experience_period: string[],
+    stringing_way: string[],
+    main_gut_id: string[],
+    cross_gut_id: string[],
+    main_gut_guage: string[],
+    cross_gut_guage: string[],
+    main_gut_tension: string[],
+    cross_gut_tension: string[],
+    racket_id: string[],
+    new_gut_date: string[],
+    change_gut_date: string[],
+    comment: string[],
+  }
+
+  const initialErrorVals = {
+    user_id: [],
+    user_height: [],
+    user_age: [],
+    experience_period: [],
+    stringing_way: [],
+    main_gut_id: [],
+    cross_gut_id: [],
+    main_gut_guage: [],
+    cross_gut_guage: [],
+    main_gut_tension: [],
+    cross_gut_tension: [],
+    racket_id: [],
+    new_gut_date: [],
+    change_gut_date: [],
+    comment: [],
+  }
+
+  const [errors, setErrors] = useState<Errors>(initialErrorVals);
+
+  //gut登録処理関連
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const registerGut = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const registerData = {
+      user_id: user.id,
+      user_height: userTennisProfile?.height,
+      user_age: userTennisProfile?.age,
+      experience_period: userTennisProfile?.experience_period,
+      stringing_way: stringingWay,
+      main_gut_id: mainGut?.id,
+      cross_gut_id: stringingWay === 'hybrid' && crossGut ? crossGut.id : mainGut?.id,
+      main_gut_guage: inputMainGutGuage,
+      cross_gut_guage: inputCrossGutGuage,
+      main_gut_tension: inputMainGutTension,
+      cross_gut_tension: inputMainCrossTension,
+      racket_id: racket?.id,
+      new_gut_date: inputNewGutDate,
+      change_gut_date: inputChangeGutDate ? inputChangeGutDate : null,
+      comment: comment,
+    }
+
+    await csrf();
+
+    await axios.post('api/my_equipments', registerData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+      }
+    }).then(res => {
+      console.log('マイ装備を追加しました。');
+
+      router.push('/my_equipments');
+    }).catch((e) => {
+      const newErrors = { ...initialErrorVals, ...e.response.data.errors };
+
+      setErrors(newErrors);
+
+      console.log('マイ装備の追加に失敗しました');
+    })
+  }
+
   return (
     <>
-      <h1>ストリングレビュー登録画面</h1>
+      <AuthCheck>
+        {(isAuth || isAuthAdmin) && (
+          <>
+            <div className="container mx-auto">
+              <div className="text-center my-6 md:mb-[32px]">
+                <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
+
+              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+
+                <form
+                  onSubmit={registerGut}
+                  className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:justify-between"
+                >
+
+                  {/* //section-one */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+                    {/* ストリング関連 */}
+                    <div>
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      {/* 張り方選択 */}
+                      <div className="w-[100%] max-w-[320px] mb-8 md:max-w-[360px]">
+                        <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
+
+                        <select
+                          name="stringing_way"
+                          id="stringing_way"
+                          value={stringingWay}
+                          onChange={onChangeInputStringingWay}
+                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
+                        >
+                          <option value="single" >単張り</option>
+                          <option value="hybrid" >ハイブリッド</option>
+                        </select>
+
+                        {errors.stringing_way.length !== 0 &&
+                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* ストリング選択セクション */}
+                      <div>
+                        <input type="hidden" name="main_gut_id" value={mainGut ? mainGut.id : undefined} />
+                        <input type="hidden" name="cross_gut_id" value={crossGut ? crossGut.id : undefined} />
+
+                        <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ストリング</p>
+
+                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">メイン</p>}
+                        <div className="mb-6">
+
+                          <div className="flex md:w-[100%] md:max-w-[360px]">
+                            <div className="w-[120px] mr-6">
+                              {mainGut && mainGut.gut_image.file_path
+                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                              }
+                            </div>
+
+                            <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                              <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{mainGut ? mainGut.maker.name_en : ''}</p>
+                                <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
+                              </div>
+
+                              <div className="flex justify-end">
+                                <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">変更</button>
+                              </div>
+                            </div>
+                          </div>
+
+                          {errors.main_gut_id.length !== 0 &&
+                            errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                          }
+                        </div>
+
+                        {/* ハイブリッド張りの時crossGutを表示 */}
+                        {stringingWay === 'hybrid' && (
+                          <>
+                            <div className=" mb-6">
+
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">クロス</p>
+
+                              <div className="flex md:w-[100%] md:max-w-[360px]">
+                                <div className="w-[120px] mr-6">
+                                  {crossGut && crossGut.gut_image.file_path
+                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  }
+                                </div>
+
+                                <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                                  <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                                  <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                    <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{crossGut ? crossGut.maker.name_ja : ''}</p>
+                                    <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
+                                  </div>
+
+                                  <div className="flex justify-end">
+                                    <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green  md:text-[16px]">変更</button>
+                                  </div>
+                                </div>
+                              </div>
+
+                              {errors.cross_gut_id.length !== 0 &&
+                                errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                              }
+                            </div>
+                          </>
+                        )}
+
+                      </div>
+
+                      {/* gut太さ選択 */}
+                      <div className="mb-[24px]">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">太さ（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={0.01}
+                            defaultValue={1.25}
+                            min="1.05"
+                            max="1.50"
+                            onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                          <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={0.01}
+                            defaultValue={1.25}
+                            min="1.05"
+                            max="1.50"
+                            onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                        </div>
+                        {errors.main_gut_guage.length !== 0 &&
+                          errors.main_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_guage.length !== 0 &&
+                          errors.cross_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gutテンション選択 */}
+                      <div className="mb-6">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">テンション（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={1}
+                            defaultValue={50}
+                            min="1"
+                            max="100"
+                            onChange={(e) => setInputMainGutTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={1}
+                            defaultValue={50}
+                            min="1"
+                            max="100"
+                            onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">ポンド</span>
+                        </div>
+                        {errors.main_gut_tension.length !== 0 &&
+                          errors.main_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_tension.length !== 0 &&
+                          errors.cross_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gutを新調日 */}
+                      <div className=" mb-6">
+                        <div className="flex flex-col">
+                          <label htmlFor="new_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張った日</label>
+                          <input
+                            type="date"
+                            name="new_gut_date"
+                            id="new_gut_date"
+                            defaultValue={today}
+                            onChange={onChangeInputNewGutDate}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                        </div>
+
+                        {errors.new_gut_date.length !== 0 &&
+                          errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gut交換日 */}
+                      <div className="mb-[40px]">
+                        <div className="flex flex-col">
+                          <label htmlFor="change_gut_date" className="text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-[8px]">張り替え・ストリングが切れた日</label>
+                          <input
+                            type="date"
+                            name="change_gut_date"
+                            id="change_gut_date"
+                            onChange={onChangeInputChangeGutDate}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                        </div>
+
+                        {errors.change_gut_date.length !== 0 &&
+                          errors.change_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* section-two */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+                    {/* ラケット関連 */}
+                    <div className="mb-[40px]">
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ラケット</p>
+
+                      <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {racket && racket.racket_image.file_path
+                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
+                          <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                          <div className="border rounded py-[8px] mb-[16px] mb-auto">
+                            <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[2px]">{racket ? racket.maker.name_en : ''}</p>
+                            <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{racket ? racket.name_ja : '未選択'}</p>
+                          </div>
+
+                          <div className="flex justify-end">
+                            <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">ラケットを選択</button>
+                          </div>
+                        </div>
+                      </div>
+
+                      {errors.racket_id.length !== 0 &&
+                        errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+
+                    <div className="mb-[48px] md:flex md:flex-col md:mb-[64px]">
+                      <label htmlFor="comment">コメント</label>
+                      <textarea
+                        name="comment"
+                        id="comment"
+                        onChange={(e) => setComment(e.target.value)}
+                        className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
+                      />
+
+                      {errors.comment.length !== 0 &&
+                        errors.comment.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+
+                    <div className="flex justify-center md:justify-end">
+                      <button
+                        type="submit"
+                        className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
+                      >追加する</button>
+                    </div>
+                  </div>
+
+                </form>
+
+                {/* gut検索モーダル */}
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
+                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                        {/* ガット */}
+                        {searchedGuts && searchedGuts.map(gut => (
+                          <>
+                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                              <div className="w-[120px] mr-6">
+                                {gut.gut_image.file_path
+                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                }
+                              </div>
+
+                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
+                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
+                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                              </div>
+                            </div>
+                          </>
+                        ))}
+
+                      </div>
+
+                      <Pagination
+                        paginator={gutsPaginator}
+                        paginate={getSearchedGutsList}
+                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                      />
+                    </div>
+
+                  </div>
+                </div>
+
+                {/* racket検索モーダル */}
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                        {/* ラケット */}
+                        {searchedRackets && searchedRackets.map(racket => (
+                          <>
+                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                              <div className="w-[120px] mr-6">
+                                {racket.racket_image.file_path
+                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                                }
+                              </div>
+
+                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
+                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
+                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                              </div>
+                            </div>
+                          </>
+                        ))}
+                      </div>
+
+                      <Pagination
+                        paginator={racketsPaginator}
+                        paginate={getSearchedRacketsList}
+                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+
+        )}
+      </AuthCheck>
+
     </>
   );
 }
 
 export default GutReviewRegister;
+


### PR DESCRIPTION
issue: #102 

背景：
gutレビュー関連画面が一覧、詳細ページのみ実装してあり、登録画面をまだ実装していなかった

やったこと：

- [ ] headerにgutレビュー投稿ページへのリンクを作成
- [ ] 装備構成と評価に分かれているレイアウトの装備構成の部分のレイアウトの作成
- [ ] 装備構成と評価に分かれているレイアウトの評価の部分のレイアウトの作成
- [ ] myEquipment検索モーダルを作成
    - MyEquipmentCardコンポーネントを作成し実装

- [ ] review登録処理を実装
- [ ] エラーメッセージ表示機能を実装

備考：

ガットレビューregisterページはmy_equipment登録ページのコードをコピーし流用している。
また、registerページファイルが1000行を超えてしまっており、肥大化した原因としてgut, racket, my_equipmentそれぞれの検索モーダルを同一ページで直書きで記述してしまっているので、各モーダルをコンポーネントとして切り出した方が良いかもしれない。今回はそれは時間の問題でやっていない。


レビューお願いします
