### PR TITLE
add: gutレビュー更新ページの作成

### DIFF
--- a/src/components/EvaluationRangeItem.tsx
+++ b/src/components/EvaluationRangeItem.tsx
@@ -4,7 +4,8 @@ type EvaluationRangeItemProps = {
   labelText: string,
   scale: boolean,
   onChangeInputRangeHnadler: (e: React.ChangeEvent<HTMLInputElement>) => void
-  valueState?: number | null,
+  // valueState?: number | null,
+  valueState?: number,
   className?: string
 }
 
@@ -12,7 +13,7 @@ const EvaluationRangeItem: React.FC<EvaluationRangeItemProps> = ({
   labelText,
   scale = false,
   onChangeInputRangeHnadler,
-  valueState,
+  valueState = 3,
   className
 }) => {
   return (
@@ -27,7 +28,7 @@ const EvaluationRangeItem: React.FC<EvaluationRangeItemProps> = ({
           min={1}
           max={5}
           step={0.5}
-          value={3}
+          value={valueState}
           chengeHandler={onChangeInputRangeHnadler}
         />
 

--- a/src/components/inputRange.tsx
+++ b/src/components/inputRange.tsx
@@ -20,7 +20,8 @@ const InputRange: React.FC<InputRangeProps> = ({
         min={min}
         max={max}
         step={step}
-        defaultValue={value}
+        // defaultValue={value}
+        value={value}
         onChange={chengeHandler}
         className={`
           w-full bg-transparent cursor-pointer appearance-none disabled:opacity-50 disabled:pointer-events-none focus:outline-none

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -295,10 +295,6 @@ const GutReviewEdit: NextPage = () => {
   }
 
   type Errors = {
-    // user_id: string[],
-    // user_height: string[],
-    // user_age: string[],
-    // experience_period: string[],
     stringing_way: string[],
     main_gut_id: string[],
     cross_gut_id: string[],
@@ -311,10 +307,6 @@ const GutReviewEdit: NextPage = () => {
   }
 
   const initialErrorVals = {
-    // user_id: [],
-    // user_height: [],
-    // user_age: [],
-    // experience_period: [],
     stringing_way: [],
     main_gut_id: [],
     cross_gut_id: [],
@@ -354,8 +346,6 @@ const GutReviewEdit: NextPage = () => {
       editedData.cross_gut_tension = inputMainCrossTension;
       editedData.racket_id = racket?.id;
     }
-
-    // console.log('editedData', editedData)
 
     await csrf();
 
@@ -399,7 +389,6 @@ const GutReviewEdit: NextPage = () => {
       setReviewComment(review.review)
     }
   }
-
 
   // myEquipment編集可否の状態変更
   const activateEdittingMyEquipment = () => {

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from "next";
-import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile"; 
+import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile";
 import type { Gut, MyEquipment, Review } from "..";
-import type { Age, Height } from "@/pages/users/[id]/edit/tennis_profile"; 
+import type { Age, Height } from "@/pages/users/[id]/edit/tennis_profile";
 
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
@@ -133,6 +133,9 @@ const GutReviewEdit: NextPage = () => {
   console.log('performanceDurability', performanceDurability)
   const [reviewComment, setReviewComment] = useState<string>('');
   console.log('reviewComment', reviewComment)
+
+  // 装備構成のmyEquipment情報を編集するかどうかの識別値
+  const [needEditingMyEquipment, setNeedEditingMyEquipment] = useState<boolean>(false);
 
   useEffect(() => {
     const getMakerList = async () => {
@@ -461,15 +464,27 @@ const GutReviewEdit: NextPage = () => {
   }
 
   const resetState = () => {
-    setMyEquipment(undefined);
-    setStringingWay('single')
-    setMainGut(undefined)
-    setCrossGut(undefined)
-    setRacket(undefined)
-    setInputMainGutGuage(1.25)
-    setInputCrossGutGuage(1.25)
-    setInputMainGutTension(50)
-    setInputMainCrossTension(50)
+    // setMyEquipment(undefined);
+    // setStringingWay('single')
+    // setMainGut(undefined)
+    // setCrossGut(undefined)
+    // setRacket(undefined)
+    // setInputMainGutGuage(1.25)
+    // setInputCrossGutGuage(1.25)
+    // setInputMainGutTension(50)
+    // setInputMainCrossTension(50)
+
+    inactivateEdittingMyEquipment();
+  }
+
+  
+  // myEquipment編集可否の状態変更
+  const activateEdittingMyEquipment = () => {
+    setNeedEditingMyEquipment(true);
+  }
+
+  const inactivateEdittingMyEquipment = () => {
+    setNeedEditingMyEquipment(false);
   }
 
   return (
@@ -497,9 +512,9 @@ const GutReviewEdit: NextPage = () => {
                     </div>
 
                     <div className="flex justify-end">
-                      {myEquipment
+                      {needEditingMyEquipment
                         ? <button type="button" onClick={resetState} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">リセット</button>
-                        : <button type="button" onClick={openMyEquipmentSearchModal} className="text-white font-bold text-[14px] w-[160px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">マイ装備から選択</button>
+                        : <button type="button" onClick={activateEdittingMyEquipment} className="text-white font-bold text-[14px] w-[160px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">マイ装備を編集</button>
                       }
                     </div>
 
@@ -519,7 +534,7 @@ const GutReviewEdit: NextPage = () => {
                           id="stringing_way"
                           value={stringingWay}
                           onChange={onChangeInputStringingWay}
-                          disabled={!!myEquipment}
+                          disabled={!needEditingMyEquipment}
                           className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
                         >
                           <option value="single" >単張り</option>
@@ -557,7 +572,7 @@ const GutReviewEdit: NextPage = () => {
                                 <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
                               </div>
 
-                              {!myEquipment && (
+                              {needEditingMyEquipment && (
                                 <>
                                   <div className="flex justify-end">
                                     <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">変更</button>
@@ -572,7 +587,6 @@ const GutReviewEdit: NextPage = () => {
                           }
                         </div>
 
-                        {/* ハイブリッド張りの時crossGutを表示 */}
                         {stringingWay === 'hybrid' && (
                           <>
                             <div className=" mb-6">
@@ -595,7 +609,7 @@ const GutReviewEdit: NextPage = () => {
                                     <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
                                   </div>
 
-                                  {!myEquipment && (
+                                  {needEditingMyEquipment && (
                                     <>
                                       <div className="flex justify-end">
                                         <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green  md:text-[16px]">変更</button>
@@ -625,7 +639,7 @@ const GutReviewEdit: NextPage = () => {
                             value={inputMainGutGuage}
                             min="1.05"
                             max="1.50"
-                            disabled={!!myEquipment}
+                            disabled={!needEditingMyEquipment}
                             onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
@@ -638,7 +652,7 @@ const GutReviewEdit: NextPage = () => {
                             value={inputCrossGutGuage}
                             min="1.05"
                             max="1.50"
-                            disabled={!!myEquipment}
+                            disabled={!needEditingMyEquipment}
                             onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
@@ -663,7 +677,7 @@ const GutReviewEdit: NextPage = () => {
                             value={inputMainGutTension}
                             min="1"
                             max="100"
-                            disabled={!!myEquipment}
+                            disabled={!needEditingMyEquipment}
                             onChange={(e) => setInputMainGutTension(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
@@ -675,7 +689,7 @@ const GutReviewEdit: NextPage = () => {
                             value={inputMainCrossTension}
                             min="1"
                             max="100"
-                            disabled={!!myEquipment}
+                            disabled={!needEditingMyEquipment}
                             onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
                             className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
                           />
@@ -715,7 +729,7 @@ const GutReviewEdit: NextPage = () => {
                             <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{racket ? racket.name_ja : '未選択'}</p>
                           </div>
 
-                          {!myEquipment && (
+                          {needEditingMyEquipment && (
                             <>
                               <div className="flex justify-end">
                                 <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">ラケットを選択</button>
@@ -930,106 +944,6 @@ const GutReviewEdit: NextPage = () => {
                   </div>
                 </div>
 
-                {/* my_equipment検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${myEquipmentSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[360px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeMyEquipmentSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchMyEquipments} className="mb-[24px] md:flex md:flex-wrap md:justify-center md:mb-[40px]">
-                      {/* キーワード検索 */}
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputMyEquipmentSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      {/* 張り方 */}
-                      <div className="w-[100%] max-w-[320px] mb-8 md:max-w-[160px] md:mb-0 md:mr-4">
-                        <label htmlFor="stringing_way" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリングの張り方</label>
-
-                        <select
-                          name="stringing_way"
-                          id="stringing_way"
-                          value={inputMyEquipmentSearchStringingWay}
-                          onChange={(e) => setInputMyEquipmentSearchStringingWay(e.target.value)}
-                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
-                        >
-                          <option value="" >未選択</option>
-                          <option value="single" >単張り</option>
-                          <option value="hybrid" >ハイブリッド</option>
-                        </select>
-
-                        {/* {errors.stringing_way.length !== 0 &&
-                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                        } */}
-                      </div>
-
-                      {/* gutを新調日 */}
-                      <div className="mb-6 md:w-[240px] md:mb-0">
-                        <div className="flex flex-wrap ">
-                          <label
-                            htmlFor="search_date"
-                            className="text-[14px] mb-1 basis-[320px] md:basis-[160px] md:text-[16px]  md:mb-[8px]"
-                          >張った日</label>
-
-                          <input
-                            type="date"
-                            name="search_date"
-                            id="search_date"
-                            defaultValue={today}
-                            onChange={(e) => setInputMyEquipmentSearchDate(e.target.value)}
-                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
-                          />
-
-                          <select
-                            name="date_range_type"
-                            id="date_range_type"
-                            value={inputMyEquipmentSearchDateRangeType}
-                            onChange={(e) => setInputMyEquipmentSearchDateRangeType(e.target.value)}
-                            className="border border-gray-300 rounded w-[80px] h-10 p-2 focus:outline-sub-green"
-                          >
-                            <option value="or_more" >以降</option>
-                            <option value="or_less" >以前</option>
-                          </select>
-                        </div>
-
-                        {errors.new_gut_date.length !== 0 &&
-                          errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                        }
-                      </div>
-
-                      <div className="flex justify-end md:justify-end basis-[100%] md:mr-[34px] md:mt-4">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[360px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap gap-[48px] w-[100%] max-w-[360px] md:max-w-[768px] md:mx-auto">
-                        {searchedMyEquipments && (
-                          searchedMyEquipments.map(myEquipment => {
-                            return (
-                              <>
-                                <MyEquipmentCard
-                                  myEquipment={myEquipment}
-                                  clickHandler={() => selectMyEquipment(myEquipment)}
-                                />
-                              </>
-                            );
-                          })
-                        )}
-                      </div>
-
-                      <Pagination
-                        paginator={myEquipmentsPaginator}
-                        paginate={getSearchedMyEquipmentsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
           </>

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -1,0 +1,9 @@
+const GutReviewEdit = () => {
+  return (
+    <>
+      <h1>gutレビュー更新ページ</h1>
+    </>
+  );
+}
+
+export default GutReviewEdit;

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -1,7 +1,6 @@
 import type { NextPage } from "next";
 import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile";
 import type { Gut, MyEquipment, Review } from "..";
-import type { Age, Height } from "@/pages/users/[id]/edit/tennis_profile";
 
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
@@ -17,7 +16,6 @@ import TextUnderBar from "@/components/TextUnderBar";
 import { IoClose } from "react-icons/io5";
 import Pagination, { Paginator } from "@/components/Pagination";
 import EvaluationRangeItem from "@/components/EvaluationRangeItem";
-import MyEquipmentCard from "@/components/MyEquipmentCard";
 import { getToday } from "@/modules/getToday";
 
 type EditingGutReviewData = {
@@ -47,10 +45,7 @@ const GutReviewEdit: NextPage = () => {
 
   const today: string = getToday();
 
-  const [userTennisProfile, setUserTennisProfile] = useState<TennisProfile>();
-
   const [review, setReview] = useState<Review>();
-  console.log('review', review)
 
   //my_equipmentの登録に使うstate群
   const [stringingWay, setStringingWay] = useState<string>('single');
@@ -63,7 +58,6 @@ const GutReviewEdit: NextPage = () => {
 
   //要素の表示などに使用するstate群
   const [myEquipment, setMyEquipment] = useState<MyEquipment>();
-  console.log('myEquipmentOfUser', myEquipment)
 
   const [makers, setMakers] = useState<Maker[]>();
 
@@ -78,8 +72,6 @@ const GutReviewEdit: NextPage = () => {
 
   const [inputMainCrossTension, setInputCrossGutTension] = useState<number>(50);
 
-  const [inputNewGutDate, setInputNewGutDate] = useState<string>(today);
-
   //モーダルの開閉に関するstate
   const [modalVisibility, setModalVisibility] = useState<boolean>(false);
 
@@ -90,8 +82,6 @@ const GutReviewEdit: NextPage = () => {
   const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   const [myEquipmentSearchModalVisibility, setMyEquipmentModalVisibility] = useState<boolean>(false);
-
-  const [myEquipmentSearchModalVisibilityClassName, setMyEquipmentSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   //検索関連のstate
   const [inputSearchWord, setInputSearchWord] = useState<string>('');
@@ -106,31 +96,14 @@ const GutReviewEdit: NextPage = () => {
 
   const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
 
-  const [searchedMyEquipments, setSearchedEquipments] = useState<MyEquipment[]>();
-  console.log('searchedMyEquipments', searchedMyEquipments)
-  const [myEquipmentsPaginator, setMyEquipmentsPaginator] = useState<Paginator<MyEquipment>>();
-  console.log('myEquipmentsPaginator', myEquipmentsPaginator)
-
-  // myEquipment検索state群
-  const [inputMyEquipmentSearchWord, setInputMyEquipmentSearchWord] = useState<string>('');
-  console.log('inputMyEquipmentSearchWord', inputMyEquipmentSearchWord)
-  const [inputMyEquipmentSearchStringingWay, setInputMyEquipmentSearchStringingWay] = useState<string>('');
-  console.log('inputMyEquipmentSearchStringingWay', inputMyEquipmentSearchStringingWay)
-  const [inputMyEquipmentSearchDate, setInputMyEquipmentSearchDate] = useState<string>(today);
-  console.log('inputMyEquipmentSearchDate', inputMyEquipmentSearchDate)
-  const [inputMyEquipmentSearchDateRangeType, setInputMyEquipmentSearchDateRangeType] = useState<string>('or_less');
-  console.log('inputMyEquipmentSearchDateRangeType', inputMyEquipmentSearchDateRangeType)
-
-
   // 評価に関するstate
   const [matchRate, setMatchRate] = useState<number>(3);
-  console.log('matchRate', matchRate)
+
   const [pysicalDurability, setPysicalDurability] = useState<number>(3);
-  console.log('pysicalDurability', pysicalDurability)
+
   const [performanceDurability, setPerformanceDurability] = useState<number>(3);
-  console.log('performanceDurability', performanceDurability)
+
   const [reviewComment, setReviewComment] = useState<string>('');
-  console.log('reviewComment', reviewComment)
 
   // 装備構成のmyEquipment情報を編集するかどうかの識別値
   const [needEditingMyEquipment, setNeedEditingMyEquipment] = useState<boolean>(false);
@@ -139,12 +112,6 @@ const GutReviewEdit: NextPage = () => {
     const getMakerList = async () => {
       await axios.get('api/makers').then(res => {
         setMakers(res.data);
-      })
-    }
-
-    const getUserTennisProfile = async () => {
-      await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
-        setUserTennisProfile(res.data);
       })
     }
 
@@ -176,9 +143,7 @@ const GutReviewEdit: NextPage = () => {
     }
 
 
-    getUserTennisProfile();
     getMakerList();
-    // getReview();
     setInitialStates();
   }, [])
 
@@ -217,24 +182,6 @@ const GutReviewEdit: NextPage = () => {
       document.documentElement.style.overflow = 'auto';
     }
   }, [racketSearchModalVisibility])
-
-  // myEquipment検索モーダル開閉とその時の縦スクロールの挙動を考慮している
-  useEffect(() => {
-    if (myEquipmentSearchModalVisibility) {
-      setMyEquipmentSearchModalVisibilityClassName('opacity-100 scale-100')
-      document.body.style.overflow = 'hidden';
-      document.documentElement.style.overflow = 'hidden';
-    } else {
-      setMyEquipmentSearchModalVisibilityClassName('opacity-0 scale-0');
-      document.body.style.overflow = 'auto';
-      document.documentElement.style.overflow = 'auto';
-    }
-
-    return () => {
-      document.body.style.overflow = 'auto';
-      document.documentElement.style.overflow = 'auto';
-    }
-  }, [myEquipmentSearchModalVisibility])
 
   //inputの制御関数群
   const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -286,17 +233,6 @@ const GutReviewEdit: NextPage = () => {
     setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
-  // my_equipment検索モーダル開閉
-  const openMyEquipmentSearchModal = () => {
-    setMyEquipmentModalVisibility(true);
-    setMyEquipmentSearchModalVisibilityClassName('opacity-100 scale-100');
-  }
-
-  const closeMyEquipmentSearchModal = () => {
-    setMyEquipmentModalVisibility(false)
-    setMyEquipmentSearchModalVisibilityClassName('opacity-0 scale-0');
-  }
-
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
   //ページネーションを考慮した検索後gut一覧データの取得関数
@@ -343,29 +279,6 @@ const GutReviewEdit: NextPage = () => {
     }
   }
 
-  //ページネーションを考慮した検索後myEquipment一覧データの取得
-  const initialMyEquipmentSearchUrl = `api/my_equipments/user/${user.id}/search?several_words=${inputMyEquipmentSearchWord}&stringing_way=${inputMyEquipmentSearchStringingWay}&search_date=${inputMyEquipmentSearchDate}&date_range_type=${inputMyEquipmentSearchDateRangeType}`;
-  const getSearchedMyEquipmentsList = async (url: string = initialMyEquipmentSearchUrl) => {
-    await axios.get(url).then((res) => {
-      setMyEquipmentsPaginator(res.data);
-
-      setSearchedEquipments(res.data.data);
-    })
-  }
-
-  //myEquipment検索
-  const searchMyEquipments = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-
-    try {
-      getSearchedMyEquipmentsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
   const selectGut = (gut: Gut) => {
     if (witchSelectingGut === 'main') {
       setMainGut(gut);
@@ -381,26 +294,11 @@ const GutReviewEdit: NextPage = () => {
     closeRacketSearchModal();
   }
 
-  const selectMyEquipment = (myEquipment: MyEquipment) => {
-    // 一つのmyEquipmentを選び、各stateに値をセット
-    setMyEquipment(myEquipment)
-    setStringingWay(myEquipment.stringing_way)
-    setMainGut(myEquipment.main_gut)
-    setCrossGut(myEquipment.cross_gut)
-    setRacket(myEquipment.racket)
-    setInputMainGutGuage(myEquipment.main_gut_guage)
-    setInputCrossGutGuage(myEquipment.cross_gut_guage)
-    setInputMainGutTension(myEquipment.main_gut_tension)
-    setInputCrossGutTension(myEquipment.cross_gut_tension)
-
-    closeMyEquipmentSearchModal();
-  }
-
   type Errors = {
-    user_id: string[],
-    user_height: string[],
-    user_age: string[],
-    experience_period: string[],
+    // user_id: string[],
+    // user_height: string[],
+    // user_age: string[],
+    // experience_period: string[],
     stringing_way: string[],
     main_gut_id: string[],
     cross_gut_id: string[],
@@ -413,10 +311,10 @@ const GutReviewEdit: NextPage = () => {
   }
 
   const initialErrorVals = {
-    user_id: [],
-    user_height: [],
-    user_age: [],
-    experience_period: [],
+    // user_id: [],
+    // user_height: [],
+    // user_age: [],
+    // experience_period: [],
     stringing_way: [],
     main_gut_id: [],
     cross_gut_id: [],
@@ -457,7 +355,7 @@ const GutReviewEdit: NextPage = () => {
       editedData.racket_id = racket?.id;
     }
 
-    console.log('editedData', editedData)
+    // console.log('editedData', editedData)
 
     await csrf();
 

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -1,9 +1,1045 @@
-const GutReviewEdit = () => {
+import type { NextPage } from "next";
+import type { Maker, Racket, TennisProfile } from "@/pages/users/[id]/profile"; 
+import type { Gut, MyEquipment, Review } from "..";
+import type { Age, Height } from "@/pages/users/[id]/edit/tennis_profile"; 
+
+import axios from "@/lib/axios";
+import Cookies from "js-cookie";
+
+import React, { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthContext } from "@/context/AuthContext";
+
+import AuthCheck from "@/components/AuthCheck";
+import PrimaryHeading from "@/components/PrimaryHeading";
+import SubHeading from "@/components/SubHeading";
+import TextUnderBar from "@/components/TextUnderBar";
+import { IoClose } from "react-icons/io5";
+import Pagination, { Paginator } from "@/components/Pagination";
+import EvaluationRangeItem from "@/components/EvaluationRangeItem";
+import MyEquipmentCard from "@/components/MyEquipmentCard";
+import { getToday } from "@/modules/getToday";
+
+type PostingGutReviewData = {
+  match_rate: number | undefined,
+  pysical_durability: number,
+  performance_durability: number,
+  review: string,
+  equipment_id: number | null,
+  need_creating_my_equipment: boolean,
+
+  user_id?: number,
+  user_height?: Height,
+  user_age?: Age,
+  experience_period?: number,
+  stringing_way?: string,
+  main_gut_id?: number,
+  cross_gut_id?: number,
+  main_gut_guage?: number,
+  cross_gut_guage?: number,
+  main_gut_tension?: number,
+  cross_gut_tension?: number,
+  racket_id?: number,
+  new_gut_date?: string,
+  change_gut_date?: string | null,
+  comment?: string,
+}
+
+const GutReviewEdit: NextPage = () => {
+  const router = useRouter();
+
+  const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
+
+  const today: string = getToday();
+
+  const [userTennisProfile, setUserTennisProfile] = useState<TennisProfile>();
+
+  //my_equipmentの登録に使うstate群
+  const [stringingWay, setStringingWay] = useState<string>('single');
+
+  const [mainGut, setMainGut] = useState<Gut>();
+
+  const [crossGut, setCrossGut] = useState<Gut>();
+
+  const [racket, setRacket] = useState<Racket>();
+
+  //要素の表示などに使用するstate群
+  const [myEquipment, setMyEquipment] = useState<MyEquipment>();
+  console.log('myEquipment', myEquipment)
+
+  const [makers, setMakers] = useState<Maker[]>();
+
+  const [witchSelectingGut, setWitchSelectingGut] = useState<string>('');
+
+  // inputに関するstate
+  const [inputMainGutGuage, setInputMainGutGuage] = useState<number>(1.25);
+
+  const [inputCrossGutGuage, setInputCrossGutGuage] = useState<number>(1.25);
+
+  const [inputMainGutTension, setInputMainGutTension] = useState<number>(50);
+
+  const [inputMainCrossTension, setInputMainCrossTension] = useState<number>(50);
+
+  const [inputNewGutDate, setInputNewGutDate] = useState<string>(today);
+
+  //モーダルの開閉に関するstate
+  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
+
+  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
+
+  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  const [myEquipmentSearchModalVisibility, setMyEquipmentModalVisibility] = useState<boolean>(false);
+
+  const [myEquipmentSearchModalVisibilityClassName, setMyEquipmentSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  //検索関連のstate
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+
+  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+
+  const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
+
+  const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
+
+  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
+
+  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
+
+  const [searchedMyEquipments, setSearchedEquipments] = useState<MyEquipment[]>();
+  console.log('searchedMyEquipments', searchedMyEquipments)
+  const [myEquipmentsPaginator, setMyEquipmentsPaginator] = useState<Paginator<MyEquipment>>();
+  console.log('myEquipmentsPaginator', myEquipmentsPaginator)
+
+  // myEquipment検索state群
+  const [inputMyEquipmentSearchWord, setInputMyEquipmentSearchWord] = useState<string>('');
+  console.log('inputMyEquipmentSearchWord', inputMyEquipmentSearchWord)
+  const [inputMyEquipmentSearchStringingWay, setInputMyEquipmentSearchStringingWay] = useState<string>('');
+  console.log('inputMyEquipmentSearchStringingWay', inputMyEquipmentSearchStringingWay)
+  const [inputMyEquipmentSearchDate, setInputMyEquipmentSearchDate] = useState<string>(today);
+  console.log('inputMyEquipmentSearchDate', inputMyEquipmentSearchDate)
+  const [inputMyEquipmentSearchDateRangeType, setInputMyEquipmentSearchDateRangeType] = useState<string>('or_less');
+  console.log('inputMyEquipmentSearchDateRangeType', inputMyEquipmentSearchDateRangeType)
+
+
+  // 評価に関するstate
+  const [matchRate, setMatchRate] = useState<number>(3);
+  console.log('matchRate', matchRate)
+  const [pysicalDurability, setPysicalDurability] = useState<number>(3);
+  console.log('pysicalDurability', pysicalDurability)
+  const [performanceDurability, setPerformanceDurability] = useState<number>(3);
+  console.log('performanceDurability', performanceDurability)
+  const [reviewComment, setReviewComment] = useState<string>('');
+  console.log('reviewComment', reviewComment)
+
+  useEffect(() => {
+    const getMakerList = async () => {
+      await axios.get('api/makers').then(res => {
+        setMakers(res.data);
+      })
+    }
+
+    const getUserTennisProfile = async () => {
+      await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
+        setUserTennisProfile(res.data);
+      })
+    }
+
+    getUserTennisProfile();
+    getMakerList();
+  }, [])
+
+  // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (modalVisibility) {
+      setModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [modalVisibility])
+
+  // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (racketSearchModalVisibility) {
+      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [racketSearchModalVisibility])
+
+  // myEquipment検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (myEquipmentSearchModalVisibility) {
+      setMyEquipmentSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setMyEquipmentSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [myEquipmentSearchModalVisibility])
+
+  //inputの制御関数群
+  const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setStringingWay(e.target.value);
+    setCrossGut(undefined);
+  }
+
+  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setInputSearchMaker(null);
+      return
+    };
+
+    setInputSearchMaker(Number(e.target.value));
+  }
+
+  //モーダルの開閉
+  const closeModal = () => {
+    setModalVisibility(false);
+    setModalVisibilityClassName('opacity-0 scale-0')
+    setWitchSelectingGut('');
+  }
+
+  const openModal = () => {
+    setModalVisibilityClassName('opacity-100 scale-100')
+  }
+
+  //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
+  const openMainGutSearchModal = () => {
+    setModalVisibility(true);
+    openModal();
+    setWitchSelectingGut('main');
+  }
+
+  const openCrossGutSearchModal = () => {
+    setModalVisibility(true);
+    openModal();
+    setWitchSelectingGut('cross');
+  }
+
+  //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
+  const openRacketSearchModal = () => {
+    setRacketSearchModalVisibility(true);
+    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
+  }
+
+  const closeRacketSearchModal = () => {
+    setRacketSearchModalVisibility(false)
+    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
+  }
+
+  // my_equipment検索モーダル開閉
+  const openMyEquipmentSearchModal = () => {
+    setMyEquipmentModalVisibility(true);
+    setMyEquipmentSearchModalVisibilityClassName('opacity-100 scale-100');
+  }
+
+  const closeMyEquipmentSearchModal = () => {
+    setMyEquipmentModalVisibility(false)
+    setMyEquipmentSearchModalVisibilityClassName('opacity-0 scale-0');
+  }
+
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
+
+  //ページネーションを考慮した検索後gut一覧データの取得関数
+  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
+    await axios.get(url).then((res) => {
+      setGutsPaginator(res.data);
+
+      setSearchedGuts(res.data.data);
+    })
+  }
+
+  //gut検索
+  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      getSearchedGutsList();
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  //ページネーションを考慮した検索後racket一覧データの取得関数
+  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
+    await axios.get(url).then((res) => {
+      setRacketsPaginator(res.data);
+
+      setSearchedRackets(res.data.data);
+    })
+  }
+
+  //racket検索
+  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      getSearchedRacketsList();
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  //ページネーションを考慮した検索後myEquipment一覧データの取得
+  const initialMyEquipmentSearchUrl = `api/my_equipments/user/${user.id}/search?several_words=${inputMyEquipmentSearchWord}&stringing_way=${inputMyEquipmentSearchStringingWay}&search_date=${inputMyEquipmentSearchDate}&date_range_type=${inputMyEquipmentSearchDateRangeType}`;
+  const getSearchedMyEquipmentsList = async (url: string = initialMyEquipmentSearchUrl) => {
+    await axios.get(url).then((res) => {
+      setMyEquipmentsPaginator(res.data);
+
+      setSearchedEquipments(res.data.data);
+    })
+  }
+
+  //myEquipment検索
+  const searchMyEquipments = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      getSearchedMyEquipmentsList();
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  const selectGut = (gut: Gut) => {
+    if (witchSelectingGut === 'main') {
+      setMainGut(gut);
+    } else if (witchSelectingGut === 'cross') {
+      setCrossGut(gut);
+    }
+
+    closeModal();
+  }
+
+  const selectRacket = (racket: Racket) => {
+    setRacket(racket)
+    closeRacketSearchModal();
+  }
+
+  const selectMyEquipment = (myEquipment: MyEquipment) => {
+    // 一つのmyEquipmentを選び、各stateに値をセット
+    setMyEquipment(myEquipment)
+    setStringingWay(myEquipment.stringing_way)
+    setMainGut(myEquipment.main_gut)
+    setCrossGut(myEquipment.cross_gut)
+    setRacket(myEquipment.racket)
+    setInputMainGutGuage(myEquipment.main_gut_guage)
+    setInputCrossGutGuage(myEquipment.cross_gut_guage)
+    setInputMainGutTension(myEquipment.main_gut_tension)
+    setInputMainCrossTension(myEquipment.cross_gut_tension)
+
+    closeMyEquipmentSearchModal();
+  }
+
+  type Errors = {
+    user_id: string[],
+    user_height: string[],
+    user_age: string[],
+    experience_period: string[],
+    stringing_way: string[],
+    main_gut_id: string[],
+    cross_gut_id: string[],
+    main_gut_guage: string[],
+    cross_gut_guage: string[],
+    main_gut_tension: string[],
+    cross_gut_tension: string[],
+    racket_id: string[],
+    new_gut_date: string[],
+    // change_gut_date: string[],
+    // comment: string[],
+    review: string[]
+  }
+
+  const initialErrorVals = {
+    user_id: [],
+    user_height: [],
+    user_age: [],
+    experience_period: [],
+    stringing_way: [],
+    main_gut_id: [],
+    cross_gut_id: [],
+    main_gut_guage: [],
+    cross_gut_guage: [],
+    main_gut_tension: [],
+    cross_gut_tension: [],
+    racket_id: [],
+    new_gut_date: [],
+    // change_gut_date: [],
+    // comment: [],
+    review: [],
+  }
+
+  const [errors, setErrors] = useState<Errors>(initialErrorVals);
+
+  //review登録処理関連
+  const csrf = async () => await axios.get('/sanctum/csrf-cookie');
+
+  const postGutReview = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    let postingData: PostingGutReviewData = {
+      match_rate: matchRate,
+      pysical_durability: pysicalDurability,
+      performance_durability: performanceDurability,
+      review: reviewComment,
+      equipment_id: myEquipment ? myEquipment.id : null,
+      need_creating_my_equipment: myEquipment ? false : true,
+    }
+
+    // 新規でmyEquipmentの登録が必要な場合にpostingDataに必要項目を追加
+    if (!myEquipment) {
+      postingData.user_id = user.id;
+      postingData.user_height = userTennisProfile?.height;
+      postingData.user_age = userTennisProfile?.age;
+      postingData.experience_period = userTennisProfile?.experience_period;
+      postingData.stringing_way = stringingWay;
+      postingData.main_gut_id = mainGut?.id;
+      postingData.cross_gut_id = stringingWay === 'hybrid' && crossGut ? crossGut.id : mainGut?.id;
+      postingData.main_gut_guage = inputMainGutGuage;
+      postingData.cross_gut_guage = inputCrossGutGuage;
+      postingData.main_gut_tension = inputMainGutTension;
+      postingData.cross_gut_tension = inputMainCrossTension;
+      postingData.racket_id = racket?.id;
+      postingData.new_gut_date = inputNewGutDate;
+      postingData.change_gut_date = null;
+      postingData.comment = '';
+    }
+
+    console.log('postingData', postingData)
+
+    await csrf();
+
+    await axios.post('api/gut_reviews', postingData, {
+      headers: {
+        'X-Xsrf-Token': Cookies.get('XSRF-TOKEN'),
+      }
+    }).then(res => {
+      console.log('レビューを投稿しました。');
+
+      router.push('/reviews');
+    }).catch((e) => {
+      const newErrors = { ...initialErrorVals, ...e.response.data.errors };
+
+      setErrors(newErrors);
+
+      console.log('レビューを投稿に失敗しました');
+    })
+  }
+
+  const resetState = () => {
+    setMyEquipment(undefined);
+    setStringingWay('single')
+    setMainGut(undefined)
+    setCrossGut(undefined)
+    setRacket(undefined)
+    setInputMainGutGuage(1.25)
+    setInputCrossGutGuage(1.25)
+    setInputMainGutTension(50)
+    setInputMainCrossTension(50)
+  }
+
   return (
     <>
-      <h1>gutレビュー更新ページ</h1>
+      <AuthCheck>
+        {(isAuth || isAuthAdmin) && (
+          <>
+            <div className="container mx-auto mb-6">
+              <div className="text-center my-6 md:mb-[32px]">
+                <PrimaryHeading text="Post Review" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
+
+              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+
+                <form
+                  onSubmit={postGutReview}
+                  className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:justify-between"
+                >
+
+                  {/* //section-one */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+                    <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                      <SubHeading text='装備構成' className="text-[16px] md:text-[18px] md:mb-2" />
+                      <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                    </div>
+
+                    <div className="flex justify-end">
+                      {myEquipment
+                        ? <button type="button" onClick={resetState} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">リセット</button>
+                        : <button type="button" onClick={openMyEquipmentSearchModal} className="text-white font-bold text-[14px] w-[160px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">マイ装備から選択</button>
+                      }
+                    </div>
+
+                    {/* ストリング関連 */}
+                    <div>
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[84px] md:max-w-[96px]" />
+                      </div>
+
+                      {/* 張り方選択 */}
+                      <div className="w-[100%] max-w-[320px] mb-8 md:max-w-[360px]">
+                        <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
+
+                        <select
+                          name="stringing_way"
+                          id="stringing_way"
+                          value={stringingWay}
+                          onChange={onChangeInputStringingWay}
+                          disabled={!!myEquipment}
+                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
+                        >
+                          <option value="single" >単張り</option>
+                          <option value="hybrid" >ハイブリッド</option>
+                        </select>
+
+                        {errors.stringing_way.length !== 0 &&
+                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* ストリング選択セクション */}
+                      <div>
+                        <input type="hidden" name="main_gut_id" value={mainGut ? mainGut.id : undefined} />
+                        <input type="hidden" name="cross_gut_id" value={crossGut ? crossGut.id : undefined} />
+
+                        <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ストリング</p>
+
+                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">メイン</p>}
+                        <div className="mb-6">
+
+                          <div className="flex md:w-[100%] md:max-w-[360px]">
+                            <div className="w-[120px] mr-6">
+                              {mainGut && mainGut.gut_image.file_path
+                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                              }
+                            </div>
+
+                            <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                              <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{mainGut ? mainGut.maker.name_en : ''}</p>
+                                <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{mainGut ? mainGut.name_ja : '未選択'}</p>
+                              </div>
+
+                              {!myEquipment && (
+                                <>
+                                  <div className="flex justify-end">
+                                    <button type="button" onClick={openMainGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">変更</button>
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                          </div>
+
+                          {errors.main_gut_id.length !== 0 &&
+                            errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                          }
+                        </div>
+
+                        {/* ハイブリッド張りの時crossGutを表示 */}
+                        {stringingWay === 'hybrid' && (
+                          <>
+                            <div className=" mb-6">
+
+                              <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">クロス</p>
+
+                              <div className="flex md:w-[100%] md:max-w-[360px]">
+                                <div className="w-[120px] mr-6">
+                                  {crossGut && crossGut.gut_image.file_path
+                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  }
+                                </div>
+
+                                <div className="w-[100%] max-w-[176px] md:max-w-[216px]">
+                                  <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                                  <div className="border rounded py-[8px] mb-[16px] md:mb-[8px]">
+                                    <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{crossGut ? crossGut.maker.name_ja : ''}</p>
+                                    <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{crossGut ? crossGut.name_ja : '未選択'}</p>
+                                  </div>
+
+                                  {!myEquipment && (
+                                    <>
+                                      <div className="flex justify-end">
+                                        <button type="button" onClick={openCrossGutSearchModal} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green  md:text-[16px]">変更</button>
+                                      </div>
+                                    </>
+                                  )}
+                                </div>
+                              </div>
+
+                              {errors.cross_gut_id.length !== 0 &&
+                                errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                              }
+                            </div>
+                          </>
+                        )}
+
+                      </div>
+
+                      {/* gut太さ選択 */}
+                      <div className="mb-[24px]">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">太さ（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={0.01}
+                            value={inputMainGutGuage}
+                            min="1.05"
+                            max="1.50"
+                            disabled={!!myEquipment}
+                            onChange={(e) => setInputMainGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] mr-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                          <span className="inline-block text-[16px] text-center h-[18px] leading-[16px] mr-[16px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={0.01}
+                            value={inputCrossGutGuage}
+                            min="1.05"
+                            max="1.50"
+                            disabled={!!myEquipment}
+                            onChange={(e) => setInputCrossGutGuage(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[72px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">mm</span>
+                        </div>
+                        {errors.main_gut_guage.length !== 0 &&
+                          errors.main_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_guage.length !== 0 &&
+                          errors.cross_gut_guage.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      {/* gutテンション選択 */}
+                      <div className="mb-6">
+                        <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[8px]">テンション（メイン / クロス）</p>
+                        <div>
+                          <input
+                            type="number"
+                            name="main_gut_guage"
+                            step={1}
+                            value={inputMainGutTension}
+                            min="1"
+                            max="100"
+                            disabled={!!myEquipment}
+                            onChange={(e) => setInputMainGutTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[16px] text-center h-[18px] mb-[4px] leading-[16px] mr-[4px] w-[100%] max-w-[16px] md:text-[16px] md:h-[18px]">/</span>
+                          <input
+                            type="number"
+                            name="cross_gut_guage"
+                            step={1}
+                            value={inputMainCrossTension}
+                            min="1"
+                            max="100"
+                            disabled={!!myEquipment}
+                            onChange={(e) => setInputMainCrossTension(Number(e.target.value))}
+                            className="inline-block border border-gray-300 rounded w-[64px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+                          <span className="inline-block text-[14px] h-[16px] leading-[16px] md:text-[16px] md:h-[18px]">ポンド</span>
+                        </div>
+                        {errors.main_gut_tension.length !== 0 &&
+                          errors.main_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                        {errors.cross_gut_tension.length !== 0 &&
+                          errors.cross_gut_tension.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+                    </div>
+
+                    {/* ラケット関連 */}
+                    <div className="mb-[40px]">
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[64px] md:max-w-[72px]" />
+                      </div>
+
+                      <p className="text-[14px] h-[16px] mb-[8px] leading-[16px] md:text-[16px] md:h-[18px]">使用ラケット</p>
+
+                      <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {racket && racket.racket_image.file_path
+                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[176px] md:max-w-[216px] flex flex-col">
+                          <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+                          <div className="border rounded py-[8px] mb-[16px] mb-auto">
+                            <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-[2px]">{racket ? racket.maker.name_en : ''}</p>
+                            <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{racket ? racket.name_ja : '未選択'}</p>
+                          </div>
+
+                          {!myEquipment && (
+                            <>
+                              <div className="flex justify-end">
+                                <button type="button" onClick={openRacketSearchModal} className="text-white font-bold text-[14px] w-[128px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">ラケットを選択</button>
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      </div>
+
+                      {errors.racket_id.length !== 0 &&
+                        errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      }
+                    </div>
+                  </div>
+
+                  {/* section-two */}
+                  <div className="md:w-[100%] md:max-w-[360px]">
+                    <div className="w-[100%] max-w-[320px] mb-6 md:max-w-[360px]">
+                      <SubHeading text='評価' className="text-[16px] md:text-[18px] md:mb-2" />
+                      <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                    </div>
+
+                    <div>
+                      <EvaluationRangeItem
+                        labelText="自分に合っているか"
+                        scale={true}
+                        onChangeInputRangeHnadler={(e) => { setMatchRate(Number(e.target.value)) }}
+                        valueState={matchRate}
+                        className="mb-6 md:mb-2"
+                      />
+
+                      <EvaluationRangeItem
+                        labelText="切れにくさ"
+                        scale={false}
+                        onChangeInputRangeHnadler={(e) => { setPysicalDurability(Number(e.target.value)) }}
+                        valueState={pysicalDurability}
+                        className="mb-[41px] md:mb-[36px]"
+                      />
+
+                      <EvaluationRangeItem
+                        labelText="打球感の持続"
+                        scale={false}
+                        onChangeInputRangeHnadler={(e) => { setPerformanceDurability(Number(e.target.value)) }}
+                        valueState={performanceDurability}
+                        className="mb-10"
+                      />
+
+                      <div className="mb-[16px] md:flex md:flex-col">
+                        <label
+                          htmlFor="review"
+                          className="text-[14px] md:text-[16px] mb-1 md:mb-2"
+                        >コメント</label>
+
+                        <textarea
+                          name="review"
+                          id="review"
+                          onChange={(e) => setReviewComment(e.target.value)}
+                          className="inline-block border border-gray-300 rounded w-[320px] min-h-[160px] p-2 focus:outline-sub-green md:w-[360px] md:min-h-[240px]"
+                        />
+
+                        {errors.review.length !== 0 &&
+                          errors.review.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+                    </div>
+
+                    <p className="text-[14px] md:text-[16px] mb-6 md:mb-4 md:mb-4">※ 装備構成を直接入力した場合は、その構成のマイ装備も作成されます</p>
+
+                    <div className="flex justify-center md:justify-end">
+                      <button
+                        type="submit"
+                        className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green md:text-[16px] md:w-[160px]"
+                      >投稿する</button>
+                    </div>
+                    {errors.main_gut_id.length !== 0 &&
+                      errors.main_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.cross_gut_id.length !== 0 &&
+                      errors.cross_gut_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.racket_id.length !== 0 &&
+                      errors.racket_id.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.review.length !== 0 &&
+                      errors.review.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                  </div>
+
+                </form>
+
+                {/* gut検索モーダル */}
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
+                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                        {/* ガット */}
+                        {searchedGuts && searchedGuts.map(gut => (
+                          <>
+                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                              <div className="w-[120px] mr-6">
+                                {gut.gut_image.file_path
+                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                }
+                              </div>
+
+                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
+                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
+                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                              </div>
+                            </div>
+                          </>
+                        ))}
+
+                      </div>
+
+                      <Pagination
+                        paginator={gutsPaginator}
+                        paginate={getSearchedGutsList}
+                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                      />
+                    </div>
+
+                  </div>
+                </div>
+
+                {/* racket検索モーダル */}
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                        {/* ラケット */}
+                        {searchedRackets && searchedRackets.map(racket => (
+                          <>
+                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                              <div className="w-[120px] mr-6">
+                                {racket.racket_image.file_path
+                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                                }
+                              </div>
+
+                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
+                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
+                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                              </div>
+                            </div>
+                          </>
+                        ))}
+                      </div>
+
+                      <Pagination
+                        paginator={racketsPaginator}
+                        paginate={getSearchedRacketsList}
+                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* my_equipment検索モーダル */}
+                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${myEquipmentSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                  <div className="flex flex-col items-center w-[100%] max-w-[360px] mx-auto md:max-w-[768px]">
+                    <div onClick={closeMyEquipmentSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                      <IoClose size={48} />
+                    </div>
+
+                    <form action="" onSubmit={searchMyEquipments} className="mb-[24px] md:flex md:flex-wrap md:justify-center md:mb-[40px]">
+                      {/* キーワード検索 */}
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">検索ワード</label>
+                        <input type="text" name="several_words" onChange={(e) => setInputMyEquipmentSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      </div>
+
+                      {/* 張り方 */}
+                      <div className="w-[100%] max-w-[320px] mb-8 md:max-w-[160px] md:mb-0 md:mr-4">
+                        <label htmlFor="stringing_way" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリングの張り方</label>
+
+                        <select
+                          name="stringing_way"
+                          id="stringing_way"
+                          value={inputMyEquipmentSearchStringingWay}
+                          onChange={(e) => setInputMyEquipmentSearchStringingWay(e.target.value)}
+                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
+                        >
+                          <option value="" >未選択</option>
+                          <option value="single" >単張り</option>
+                          <option value="hybrid" >ハイブリッド</option>
+                        </select>
+
+                        {/* {errors.stringing_way.length !== 0 &&
+                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        } */}
+                      </div>
+
+                      {/* gutを新調日 */}
+                      <div className="mb-6 md:w-[240px] md:mb-0">
+                        <div className="flex flex-wrap ">
+                          <label
+                            htmlFor="search_date"
+                            className="text-[14px] mb-1 basis-[320px] md:basis-[160px] md:text-[16px]  md:mb-[8px]"
+                          >張った日</label>
+
+                          <input
+                            type="date"
+                            name="search_date"
+                            id="search_date"
+                            defaultValue={today}
+                            onChange={(e) => setInputMyEquipmentSearchDate(e.target.value)}
+                            className="inline-block border border-gray-300 rounded w-[140px] h-10 p-2 focus:outline-sub-green mr-1"
+                          />
+
+                          <select
+                            name="date_range_type"
+                            id="date_range_type"
+                            value={inputMyEquipmentSearchDateRangeType}
+                            onChange={(e) => setInputMyEquipmentSearchDateRangeType(e.target.value)}
+                            className="border border-gray-300 rounded w-[80px] h-10 p-2 focus:outline-sub-green"
+                          >
+                            <option value="or_more" >以降</option>
+                            <option value="or_less" >以前</option>
+                          </select>
+                        </div>
+
+                        {errors.new_gut_date.length !== 0 &&
+                          errors.new_gut_date.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        }
+                      </div>
+
+                      <div className="flex justify-end md:justify-end basis-[100%] md:mr-[34px] md:mt-4">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+
+                    {/* 検索結果表示欄 */}
+                    <div className="w-[100%] max-w-[360px] md:max-w-[768px]">
+                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                      <div className="flex justify-between flex-wrap gap-[48px] w-[100%] max-w-[360px] md:max-w-[768px] md:mx-auto">
+                        {searchedMyEquipments && (
+                          searchedMyEquipments.map(myEquipment => {
+                            return (
+                              <>
+                                <MyEquipmentCard
+                                  myEquipment={myEquipment}
+                                  clickHandler={() => selectMyEquipment(myEquipment)}
+                                />
+                              </>
+                            );
+                          })
+                        )}
+                      </div>
+
+                      <Pagination
+                        paginator={myEquipmentsPaginator}
+                        paginate={getSearchedMyEquipmentsList}
+                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+
+        )}
+      </AuthCheck>
+
     </>
   );
 }
 
 export default GutReviewEdit;
+

--- a/src/pages/reviews/[id]/review.tsx
+++ b/src/pages/reviews/[id]/review.tsx
@@ -5,6 +5,7 @@ import { AuthContext } from "@/context/AuthContext";
 import axios from "@/lib/axios";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
+import Link from "next/link";
 
 const Review = () => {
   const router = useRouter();
@@ -184,6 +185,15 @@ const Review = () => {
 
                 </div>
 
+              </div>
+
+              <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-[24px] md:justify-end md:max-w-[768px]">
+                {(review && user.id === review.user_id) && (
+                  <Link
+                    href={`/reviews/${review.id}/edit`}
+                    className="inline-block  text-[14px] text-white text-center leading-[32px] font-bold w-[80px] h-[32px] rounded  bg-sub-green md:text-[16px] md:w-[100px]"
+                  >編集</Link>
+                )}
               </div>
             </div>
           </>


### PR DESCRIPTION
_**issue:**_ #104 

_**背景：**_
gutレビュー更新画面の実装を遅らせていたため作成する。

_**やったこと：**_

- [ ] gutレビュー詳細画面に**更新画面へのリンク**を追加
- [ ] gutレビュー投稿画面のコードを参考にするため**コピー**。**コピーの履歴としてコミットを残した**
    - 一度コミットしておかなければコピー後の変更を負いにくいと思ったため 
- [ ] 装備構成（myEquipment）を編集するかを判断するneedEditingMyEquipment stateを作成し、そのstateの値によってinputの活性を制御するようにした
- [ ] 編集ページでの各inputの初期値セットと、myEquipmentとreviewのstateが変更されたとき変更前に戻せるように機能とリセットボタンを追加
- [ ] gutレビュー更新処理の実装。editGutReviewメソッドを実装
- [ ] 実装序盤にreview登録ページのコピーしてきたコードで不要となった部分や実装途中に書いてあった不要なコードを削除しリファクタリング
    
_**備考：**_
**gut登録画面のコードをコピーして流用**したためコードの変更箇所が膨大になっているので、コードを追う際は**コミット単位で確認**したほうがいいかもしれません。
また、検索モーダル各種をコンポーネントに分けるとコードが短くなって良いかと思いますが、時間の関係上今回は行っていません。

レビューお願いします