### PR TITLE
modify:#106:InputRangeコンポーネントのthumbとtrackの色を可変できるように修正

### DIFF
--- a/src/components/EvaluationRangeItem.tsx
+++ b/src/components/EvaluationRangeItem.tsx
@@ -1,4 +1,4 @@
-import InputRange from "./inputRange";
+import InputRange, { ThumbColor, TrackColor } from "./inputRange";
 
 type EvaluationRangeItemProps = {
   labelText: string,
@@ -6,7 +6,9 @@ type EvaluationRangeItemProps = {
   onChangeInputRangeHnadler: (e: React.ChangeEvent<HTMLInputElement>) => void
   // valueState?: number | null,
   valueState?: number,
-  className?: string
+  className?: string,
+  thumbColor?: ThumbColor,
+  trackColor?: TrackColor
 }
 
 const EvaluationRangeItem: React.FC<EvaluationRangeItemProps> = ({
@@ -14,7 +16,9 @@ const EvaluationRangeItem: React.FC<EvaluationRangeItemProps> = ({
   scale = false,
   onChangeInputRangeHnadler,
   valueState = 3,
-  className
+  className,
+  thumbColor,
+  trackColor,
 }) => {
   return (
     <>
@@ -30,6 +34,8 @@ const EvaluationRangeItem: React.FC<EvaluationRangeItemProps> = ({
           step={0.5}
           value={valueState}
           chengeHandler={onChangeInputRangeHnadler}
+          thumbColor={thumbColor ? thumbColor : undefined}
+          trackColor={trackColor ? trackColor : undefined}
         />
 
         {scale && (

--- a/src/components/inputRange.tsx
+++ b/src/components/inputRange.tsx
@@ -1,9 +1,18 @@
+//　thumbColor　trackColorは使いたい色のリテラル型のユニオンで下記記法を参考に追加して使用元でリテラル型として指定して使う
+export type ThumbColor = '[&::-webkit-slider-thumb]:bg-sub-green [&::-moz-range-thumb]:bg-sub-green'
+
+export type TrackColor = 
+  | '[&::-webkit-slider-runnable-track]:bg-gray-300 [&::-moz-range-track]:bg-gray-300'
+  | '[&::-webkit-slider-runnable-track]:bg-white [&::-moz-range-track]:bg-white'
+
 type InputRangeProps = {
   min: number,
   max: number,
   step: number,
   value: number,
-  chengeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void
+  chengeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void,
+  thumbColor?: ThumbColor,
+  trackColor?: TrackColor
 }
 
 const InputRange: React.FC<InputRangeProps> = ({
@@ -11,7 +20,9 @@ const InputRange: React.FC<InputRangeProps> = ({
   max,
   step,
   value,
-  chengeHandler
+  chengeHandler,
+  thumbColor = ' [&::-webkit-slider-thumb]:bg-sub-green [&::-moz-range-thumb]:bg-sub-green ',
+  trackColor = ' [&::-webkit-slider-runnable-track]:bg-gray-300 [&::-moz-range-track]:bg-gray-300 ',
 }) => {
   return (
     <>
@@ -30,7 +41,7 @@ const InputRange: React.FC<InputRangeProps> = ({
           [&::-webkit-slider-thumb]:appearance-none
           [&::-webkit-slider-thumb]:rounded-full
           [&::-webkit-slider-thumb]:shadow-[0_0_0_1px_#628B5B]
-          [&::-webkit-slider-thumb]:bg-sub-green
+          ${thumbColor}
           [&::-webkit-slider-thumb]:relative
           [&::-webkit-slider-thumb]:top-[-50%]
 
@@ -39,7 +50,7 @@ const InputRange: React.FC<InputRangeProps> = ({
           [&::-moz-range-thumb]:appearance-none
           [&::-moz-range-thumb]:rounded-full
           [&::-moz-range-thumb]:shadow-[0_0_0_1px_#628B5B]
-          [&::-moz-range-thumb]:bg-sub-green
+          ${thumbColor}
           [&::-moz-range-thumb]:relative
           [&::-moz-range-thumb]:top-[-50%]
 
@@ -47,13 +58,13 @@ const InputRange: React.FC<InputRangeProps> = ({
           [&::-webkit-slider-runnable-track]:h-[10px]
           [&::-webkit-slider-runnable-track]:border-black
           [&::-webkit-slider-runnable-track]:rounded-full
-          [&::-webkit-slider-runnable-track]:bg-gray-300
+          ${trackColor}
 
           [&::-moz-range-track]:w-full
           [&::-moz-range-track]:h-[10px]
           [&::-moz-range-track]:border-black
           [&::-moz-range-track]:rounded-full
-          [&::-moz-range-track]:bg-gray-300
+          ${trackColor}
         `}
       />
     </>


### PR DESCRIPTION
_**issue:**_ #106 

_**背景：**_
現状はInputRangeコンポーネントのスライドバーの色が**grayで設定**されており、コンポーネントの使用場所で**臨機応変に変えることができない**。具体的にはreview一覧画面でreviewを検索するモーダルでこのコンポーネントを使用したいが、モーダルの背景色がgrayで被ってしまっていて、視認しにくい状態である。

_**やったこと：**_

- [ ] InputRangeコンポーネントで**thumbColor, trackColorプロップスをリテラル型**として設定、追加
- [ ] classNameの**該当箇所**をthumbColor, trackColorで置き換え
- [ ] また、**EvaluationRangeItemコンポーネント**ごとに色を操作できるようにEvaluationRangeItemコンポーネントでも**thumbColor, trackColorプロップスを受渡するように修正**

_**備考：**_
使用したい色を追加するにはthumbColor, trackColorそれぞれ**型定義場所で使用したい色のtailwind classNameをリテラル型のユニオンとして追加**していき使用することを想定するように修正している

レビューお願いします