### PR TITLE
add: gutレビュー検索機能の実装

### DIFF
--- a/src/components/GutSearchModal.tsx
+++ b/src/components/GutSearchModal.tsx
@@ -1,0 +1,181 @@
+// コンポーネントの使い方
+// 使用先ファイルにコンポーネント本体と検索結果を扱うstate(searchedGuts)、モーダルの開閉状態を扱うstate(modalVisibility)を用意する
+// makerの情報をapiで所得、stateを介してmakerプロップスに渡す
+// 検索結果をモーダル内に表示する場合は、showingResultをtrueとする
+// 各種clickイベントの時に呼び出し元起因の処理が必要ならば、closeModalHandler、selectGutHandlerにメソッドのプロップスとして渡す
+// モーダルを利用した時の固有の背景スクロールバーの不具合はコンポーネント呼び出し元でmodalVisibilityの状態を使って改善すると良い。
+
+import { IoClose } from "react-icons/io5";
+import TextUnderBar from "./TextUnderBar";
+import Pagination, { Paginator } from "./Pagination";
+import axios from "@/lib/axios";
+import React, { useEffect, useState } from "react";
+import { Gut } from "@/pages/reviews";
+import { Maker } from "@/pages/users/[id]/profile";
+import { baseImagePath } from "@/consts/global";
+
+type GutSearchModalProps = {
+  modalVisibility: boolean,
+  setModalVisibility: React.Dispatch<React.SetStateAction<boolean>>,
+  showingResult: boolean,
+  setSearchedGuts: React.Dispatch<React.SetStateAction<Gut[] | undefined>>
+
+  // モーダルを閉じる時に呼び出し元で追加処理したい処理をメソッドとして渡す
+  closeModalHandler?: any,
+  
+  // ガットカードをクリック（select）した時に追加したい処理をメソッドとして渡す
+  selectGutHandler?: any,
+  makers?: Maker[],
+  searchedGuts?: Gut[],
+  zIndexClassName?: string,
+}
+
+const GutSearchModal: React.FC<GutSearchModalProps> = ({
+  modalVisibility,
+  setModalVisibility,
+  makers,
+  closeModalHandler,
+  selectGutHandler,
+  showingResult = false,
+  searchedGuts,
+  setSearchedGuts,
+  zIndexClassName,
+}) => {
+  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
+
+  // 検索input関連state
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+
+  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  // modalVisibility trueになった時にモーダルを開くため、開く動作はuseEffectで管理
+  useEffect(() => {
+    if (modalVisibility) {
+      setModalVisibilityClassName('opacity-100 scale-100');
+    } else {
+      setModalVisibilityClassName('opacity-0 scale-0');
+    }
+  }, [modalVisibility])
+
+  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setInputSearchMaker(null);
+      return
+    };
+
+    setInputSearchMaker(Number(e.target.value));
+  }
+
+  //ページネーションを考慮した検索後gut一覧データの取得関数
+  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
+    await axios.get(url).then((res) => {
+      setGutsPaginator(res.data);
+
+      setSearchedGuts(res.data.data);
+    })
+  }
+
+  //gut検索
+  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      getSearchedGutsList();
+
+      if(!showingResult) {
+        closeModal();
+      }
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  const closeModal = () => {
+    setModalVisibility(false);
+    setModalVisibilityClassName('opacity-0 scale-0')
+    closeModalHandler();
+  }
+
+  const selectGut = (gut: Gut) => {
+    selectGutHandler(gut);
+
+    closeModal();
+  }
+
+  return (
+    <>
+      {/* gut検索モーダル */}
+      <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll ${zIndexClassName}`}>
+        <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
+          <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+            <IoClose size={48} />
+          </div>
+
+          <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
+            <div className="mb-6 md:mb-0 md:mr-[16px]">
+              <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
+              <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+            </div>
+
+            <div className="mb-8 md:mb-0 md:mr-[24px]">
+              <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+              <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                <option value="未選択" selected>未選択</option>
+                {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+              </select>
+            </div>
+
+            <div className="flex justify-end md:justify-start">
+              <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+            </div>
+          </form>
+
+          {showingResult && (
+            <>
+              {/* 検索結果表示欄 */}
+              <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                  {/* ガット */}
+                  {searchedGuts && searchedGuts.map(gut => (
+                    <>
+                      <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {gut.gut_image.file_path
+                            ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                          <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
+                          <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
+                          <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                        </div>
+                      </div>
+                    </>
+                  ))}
+
+                </div>
+
+                <Pagination
+                  paginator={gutsPaginator}
+                  paginate={getSearchedGutsList}
+                  className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                />
+              </div>
+
+            </>
+          )}
+
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default GutSearchModal;

--- a/src/components/RacketSearchModal.tsx
+++ b/src/components/RacketSearchModal.tsx
@@ -1,0 +1,181 @@
+// コンポーネントの使い方
+// 使用先ファイルにコンポーネント本体と検索結果を扱うstate(searchedRackets)、モーダルの開閉状態を扱うstate(modalVisibility)を用意する
+// makerの情報をapiで所得、stateを介してmakerプロップスに渡す
+// 検索結果をモーダル内に表示する場合は、showingResultをtrueとする
+// 各種clickイベントの時に呼び出し元起因の処理が必要ならば、closeModalHandler、selectRacketHandlerにメソッドのプロップスとして渡す
+// モーダルを利用した時の固有の背景スクロールバーの不具合はコンポーネント呼び出し元でmodalVisibilityの状態を使って改善すると良い。
+
+import { IoClose } from "react-icons/io5";
+import TextUnderBar from "./TextUnderBar";
+import Pagination, { Paginator } from "./Pagination";
+import axios from "@/lib/axios";
+import React, { useEffect, useState } from "react";
+import { Maker, Racket } from "@/pages/users/[id]/profile";
+import { baseImagePath } from "@/consts/global";
+
+type RacketSearchModalProps = {
+  modalVisibility: boolean,
+  setModalVisibility: React.Dispatch<React.SetStateAction<boolean>>,
+  showingResult: boolean,
+  setSearchedRackets: React.Dispatch<React.SetStateAction<Racket[] | undefined>>
+
+  // モーダルを閉じる時に呼び出し元で追加処理したい処理をメソッドとして渡す
+  closeModalHandler?: any,
+
+  // racketカードをクリック（select）した時に追加したい処理をメソッドとして渡す
+  selectRacketHandler?: any,
+  makers?: Maker[],
+  searchedRackets?: Racket[],
+  zIndexClassName?: string,
+}
+
+const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
+  modalVisibility,
+  setModalVisibility,
+  makers,
+  closeModalHandler,
+  selectRacketHandler,
+  showingResult = false,
+  searchedRackets,
+  setSearchedRackets,
+  zIndexClassName,
+}) => {
+  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
+
+  // 検索input関連state
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+
+  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  // modalVisibility trueになった時にモーダルを開くため、開く動作はuseEffectで管理
+  // コンポーネント外で開く処理を記述するのでこうなった
+  useEffect(() => {
+    if (modalVisibility) {
+      setModalVisibilityClassName('opacity-100 scale-100');
+    } else {
+      setModalVisibilityClassName('opacity-0 scale-0');
+    }
+  }, [modalVisibility])
+
+  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === '未選択') {
+      setInputSearchMaker(null);
+      return
+    };
+
+    setInputSearchMaker(Number(e.target.value));
+  }
+
+  //ページネーションを考慮した検索後racket一覧データの取得関数
+  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
+    await axios.get(url).then((res) => {
+      setRacketsPaginator(res.data);
+
+      setSearchedRackets(res.data.data);
+    })
+  }
+
+  // racket検索
+  const searchRackets = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      getSearchedRacketsList();
+
+      if (!showingResult) {
+        closeModal();
+      }
+
+      console.log('検索完了しました')
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  const closeModal = () => {
+    setModalVisibility(false);
+    setModalVisibilityClassName('opacity-0 scale-0')
+    closeModalHandler();
+  }
+
+  const selectRacket = (racket: Racket) => {
+    selectRacketHandler(racket);
+
+    closeModal();
+  }
+
+  return (
+    <>
+      {/* racket検索モーダル */}
+      <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll ${zIndexClassName}`}>
+        <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
+          <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+            <IoClose size={48} />
+          </div>
+
+          <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
+            <div className="mb-6 md:mb-0 md:mr-[16px]">
+              <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
+              <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+            </div>
+
+            <div className="mb-8 md:mb-0 md:mr-[24px]">
+              <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
+
+              <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                <option value="未選択" selected>未選択</option>
+                {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+              </select>
+            </div>
+
+            <div className="flex justify-end md:justify-start">
+              <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+            </div>
+          </form>
+
+          {showingResult && (
+            <>
+              {/* 検索結果表示欄 */}
+              <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
+                <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
+                <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
+                  {/* ラケット */}
+                  {searchedRackets && searchedRackets.map(racket => (
+                    <>
+                      <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {racket.racket_image.file_path
+                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                          <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
+                          <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
+                          <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                        </div>
+                      </div>
+                    </>
+                  ))}
+
+                </div>
+
+                <Pagination
+                  paginator={racketsPaginator}
+                  paginate={getSearchedRacketsList}
+                  className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
+                />
+              </div>
+
+            </>
+          )}
+
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default RacketSearchModal;

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -1,8 +1,11 @@
+import { useEffect } from "react";
+
 type SelectBoxProps = {
   labelText: string,
   type?: string,
   onChangeHandler?: any,
   optionValues: string[],
+  value?: any
   className?: string,
 }
 
@@ -11,13 +14,21 @@ const SelectBox: React.FC<SelectBoxProps> = ({
   type,
   onChangeHandler,
   optionValues,
+  value,
   className,
 }) => {
   return (
     <>
       <label htmlFor={type} className="block text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-2">{labelText}</label>
 
-      <select name={type} id={type} value={type} onChange={onChangeHandler} className={` border border-gray-300 rounded ${className} p-2 focus:outline-sub-green`}>
+      <select
+        name={type}
+        id={type}
+        value={value}
+        // defaultValue={value}
+        onChange={onChangeHandler}
+        className={` border border-gray-300 rounded ${className} p-2 focus:outline-sub-green`}
+      >
         {optionValues.map(_value => (<option key={_value} value={_value}>{_value}</option>))}
       </select>
     </>

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -1,0 +1,27 @@
+type SelectBoxProps = {
+  labelText: string,
+  type?: string,
+  onChangeHandler?: any,
+  optionValues: string[],
+  className?: string,
+}
+
+const SelectBox: React.FC<SelectBoxProps> = ({
+  labelText,
+  type,
+  onChangeHandler,
+  optionValues,
+  className,
+}) => {
+  return (
+    <>
+      <label htmlFor={type} className="block text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-2">{labelText}</label>
+
+      <select name={type} id={type} value={type} onChange={onChangeHandler} className={` border border-gray-300 rounded ${className} p-2 focus:outline-sub-green`}>
+        {optionValues.map(_value => (<option key={_value} value={_value}>{_value}</option>))}
+      </select>
+    </>
+  );
+}
+
+export default SelectBox;

--- a/src/components/SelectedToolWithoutImage.tsx
+++ b/src/components/SelectedToolWithoutImage.tsx
@@ -1,0 +1,43 @@
+import { Gut } from "@/pages/reviews";
+import { Racket } from "@/pages/users/[id]/profile";
+
+type SelectedToolWithoutImageProps = {
+  tool?: Gut | Racket,
+  type: 'gut' | 'racket',
+  selectBtnVisible: boolean,
+  btnText?: string,
+  btnClickHandler?: any,
+}
+
+const SelectedToolWithoutImage: React.FC<SelectedToolWithoutImageProps> = ({
+  tool,
+  type,
+  selectBtnVisible,
+  btnText = 'ボタン',
+  btnClickHandler,
+}) => {
+  return (
+    <>
+        <div className="flex justify-between gap-[24px] w-[100%] max-w-[320px] md:max-w-[216px]">
+          <div>
+            <p className="text-[14px] h-[16px] mb-[4px] leading-[16px] md:text-[16px] md:h-[18px]">選択中</p>
+
+            <div className="w-[216px] border rounded py-[8px] bg-white">
+              <p className="text-[14px] pb-1 h-[16px] pl-[16px] leading-[16px] md:text-[16px] md:h-[18px] md:mb-1">{tool ? tool.maker.name_en : ''}</p>
+              <p className="text-[16px] text-center h-[18px] leading-[18px] md:text-[18px] md:h-[20px]">{tool ? tool.name_ja : '未選択'}</p>
+            </div>
+          </div>
+
+          {selectBtnVisible && (
+            <>
+              <div className="flex justify-end mt-[20px]">
+                <button type="button" onClick={btnClickHandler} className="text-white font-bold text-[14px] w-[80px] h-[32px] rounded ml-auto  bg-sub-green md:text-[16px]">{btnText}</button>
+              </div>
+            </>
+          )}
+        </div>
+    </>
+  );
+}
+
+export default SelectedToolWithoutImage;

--- a/src/consts/global.ts
+++ b/src/consts/global.ts
@@ -1,0 +1,3 @@
+// dbに登録している画像pathはimages/~で始まっており、
+// 実際に参照したいpathは「https:~strage/images~」で参照したいため
+export const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'

--- a/src/hooks/useTennisProfileForm.ts
+++ b/src/hooks/useTennisProfileForm.ts
@@ -132,6 +132,18 @@ const useTennisProfileForm = () => {
     physique,
 
     // setState関数
+    setExperiencePeriod,
+    setFrequency,
+    setPlayStyle,
+    setGripForm,
+    setFavaritShot,
+    setWeakShot,
+    setAge,
+    setGender,
+    setHeight,
+    setPhysique,
+
+    // form、input変更メソッド関連
     onChangeExperiencePeriod,
     onChangeFrequency,
     onChangePlayStyle,

--- a/src/hooks/useTennisProfileForm.ts
+++ b/src/hooks/useTennisProfileForm.ts
@@ -1,0 +1,159 @@
+import { Age, FavaritShot, Frequency, Gender, GripForm, Height, Physique, PlayStyle, WeakShot } from "@/pages/users/[id]/edit/tennis_profile";
+import { useState } from "react";
+
+const useTennisProfileForm = () => {
+  const [experiencePeriod, setExperiencePeriod] = useState<number | undefined>();
+  const [frequency, setFrequency] = useState<Frequency | undefined>();
+  const [playStyle, setPlayStyle] = useState<PlayStyle | undefined>();
+  const [gripForm, setGripForm] = useState<GripForm | undefined>();
+  const [favaritShot, setFavaritShot] = useState<FavaritShot | undefined>();
+  const [weakShot, setWeakShot] = useState<WeakShot | undefined>();
+  const [age, setAge] = useState<Age | undefined>();
+  const [gender, setGender] = useState<Gender | undefined>();
+  const [height, setHeight] = useState<Height | undefined>();
+  const [physique, setPhysique] = useState<Physique | undefined>();
+
+  const frequencys: Frequency[] = ['未設定', '週１回', '週２回', '週３回', '週４回', '週５回', '週６回', '月１回', '月２回', '月３回', '月４回', "毎日"]
+  const playStyles: PlayStyle[] = ['未設定', 'オールラウンダー', 'ストローカー', 'ビッグサーバー', 'サーブアンドボレーヤー']
+  const gripForms: GripForm[] = ['未設定', 'コンチネンタル', 'イースタン', 'セミウェスタン', 'ウェスタン', 'フルウェスタン']
+  const favaritShots: FavaritShot[] = ['未設定', 'フォアハンド', 'バックハンド', 'サーブ', 'フォアハンドボレー', 'バックハンドボレー']
+  const weakShots: WeakShot[] = ['未設定', 'フォアハンド', 'バックハンド', 'サーブ', 'フォアハンドボレー', 'バックハンドボレー']
+  const ages: Age[] = ['未設定', '１０代前半', '１０代後半', '２０代前半', '２０代後半', '３０代前半', '３０代後半', '４０代前半', '４０代後半', '５０代前半', '５０代後半', '６０代以上'];
+  const genders: Gender[] = ['未設定', '男', '女'];
+  const heights: Height[] = ['未設定', '高い', 'やや高い', '普通', 'やや小柄', '小柄'];
+  const physiques: Physique[] = ['未設定', '普通', 'がっしり'];
+
+  const onChangeExperiencePeriod = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setExperiencePeriod(Number(e.target.value));
+  }
+
+  const onChangeFrequency = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    //asでFrequency型に変換する前にインプット値のFrequency型との比較
+    frequencys.forEach(frequency => {
+      if (e.target.value === frequency) {
+        setFrequency(e.target.value as Frequency);
+      }
+    })
+
+    return
+  }
+
+  const onChangePlayStyle = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    playStyles.forEach(playStyle => {
+      if (e.target.value === playStyle) {
+        setPlayStyle(e.target.value as PlayStyle);
+      }
+    })
+
+    return
+  }
+
+  const onChangeGripForm = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    gripForms.forEach(gripForm => {
+      if (e.target.value === gripForm) {
+        setGripForm(e.target.value as GripForm);
+      }
+    })
+
+    return
+  }
+
+  const onChangeFavaritShot = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    favaritShots.forEach(favaritShot => {
+      if (e.target.value === favaritShot) {
+        setFavaritShot(e.target.value as FavaritShot);
+      }
+    })
+
+    return
+  }
+
+  const onChangeWeakShot = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    weakShots.forEach(weakShot => {
+      if (e.target.value === weakShot) {
+        setWeakShot(e.target.value as WeakShot);
+      }
+    })
+
+    return
+  }
+
+  const onChangeAge = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    ages.forEach(age => {
+      if (e.target.value === age) {
+        setAge(e.target.value as Age);
+      }
+    })
+
+    return
+  }
+
+  const onChangeGender = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    genders.forEach(gender => {
+      if (e.target.value === gender) {
+        setGender(e.target.value as Gender);
+      }
+    })
+
+    return
+  }
+
+  const onChangeHeight = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    heights.forEach(height => {
+      if (e.target.value === height) {
+        setHeight(e.target.value as Height);
+      }
+    })
+
+    return
+  }
+
+  const onChangePhysique = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    physiques.forEach(physique => {
+      if (e.target.value === physique) {
+        setPhysique(e.target.value as Physique);
+      }
+    })
+
+    return
+  }
+
+  return {
+    // state値
+    experiencePeriod,
+    frequency,
+    playStyle,
+    gripForm,
+    favaritShot,
+    weakShot,
+    age,
+    gender,
+    height,
+    physique,
+
+    // setState関数
+    onChangeExperiencePeriod,
+    onChangeFrequency,
+    onChangePlayStyle,
+    onChangeGripForm,
+    onChangeFavaritShot,
+    onChangeWeakShot,
+    onChangeAge,
+    onChangeGender,
+    onChangeHeight,
+    onChangePhysique,
+
+    // リテラル型のユニオンにある値を配列で表したもの
+    frequencys,
+    playStyles,
+    gripForms,
+    favaritShots,
+    weakShots,
+    ages,
+    genders,
+    heights,
+    physiques,
+  }
+}
+
+export default useTennisProfileForm;

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -105,6 +105,18 @@ const ReviewList = () => {
     physique,
 
     // setState関数
+    setExperiencePeriod,
+    setFrequency,
+    setPlayStyle,
+    setGripForm,
+    setFavaritShot,
+    setWeakShot,
+    setAge,
+    setGender,
+    setHeight,
+    setPhysique,
+
+    // form、input変更メソッド関連
     onChangeExperiencePeriod,
     onChangeFrequency,
     onChangePlayStyle,
@@ -127,16 +139,16 @@ const ReviewList = () => {
     heights,
     physiques,
   } = useTennisProfileForm();
-  // console.log('experiencePeriod', experiencePeriod)
-  // console.log('frequency', frequency)
-  // console.log('playStyle', playStyle)
-  // console.log('favaritShot', favaritShot)
-  // console.log('gripForm', gripForm)
-  // console.log('age', age)
-  // console.log('weakShot', weakShot)
-  // console.log('gender', gender)
-  // console.log('height', height)
-  // console.log('physique', physique)
+  console.log('experiencePeriod', experiencePeriod)
+  console.log('frequency', frequency)
+  console.log('playStyle', playStyle)
+  console.log('favaritShot', favaritShot)
+  console.log('gripForm', gripForm)
+  console.log('age', age)
+  console.log('weakShot', weakShot)
+  console.log('gender', gender)
+  console.log('height', height)
+  console.log('physique', physique)
 
   // 各種検索結果state
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
@@ -171,11 +183,11 @@ const ReviewList = () => {
   }, [])
 
   // 評価に関するstate
-  const [matchRate, setMatchRate] = useState<number>(3);
+  const [matchRate, setMatchRate] = useState<number>(1);
   console.log('matchRate', matchRate)
-  const [pysicalDurability, setPysicalDurability] = useState<number>(3);
+  const [pysicalDurability, setPysicalDurability] = useState<number>(1);
   console.log('pysicalDurability', pysicalDurability)
-  const [performanceDurability, setPerformanceDurability] = useState<number>(3);
+  const [performanceDurability, setPerformanceDurability] = useState<number>(1);
   console.log('performanceDurability', performanceDurability)
 
   //モーダルの開閉に関するstate
@@ -245,7 +257,7 @@ const ReviewList = () => {
   }
 
   // racket検索モーダル関連
-  const closeRacketSearchModalHandler = () => {}
+  const closeRacketSearchModalHandler = () => { }
 
   const openRacketSearchModal = () => {
     setRacketSearchModalVisibility(true);
@@ -255,7 +267,7 @@ const ReviewList = () => {
     setRacket(racket);
   }
 
-  const [stringingWay, setStringingWay] = useState<string>('single');
+  const [stringingWay, setStringingWay] = useState<string>();
   console.log('stringingWay', stringingWay)
 
   const [mainGut, setMainGut] = useState<Gut>();
@@ -273,16 +285,94 @@ const ReviewList = () => {
     setCrossGut(undefined);
   }
 
-  const searchReview = () => {
+  // const searchReviews = (e: React.FormEvent<HTMLFormElement>) => {
 
+  // }
+
+  const searchReviews = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    await axios.get('api/gut_reviews/search', {
+      params: {
+        match_rate: matchRate,
+        pysical_durability: pysicalDurability,
+        performance_durability: performanceDurability,
+        search_range_type: 'or_more',
+        // search_range_type: 'or_less',
+        racket_id: racket?.id,
+        stringing_way: (stringingWay && stringingWay !== '未設定') ? stringingWay : undefined,
+        main_gut_id: mainGut?.id,
+        cross_gut_id: crossGut?.id,
+
+        user_height: (height && height !== '未設定') ? height : undefined,
+        user_age: (age && age !== '未設定') ? age : undefined,
+        experience_period: experiencePeriod,
+        gender: (gender && gender !== '未設定') ? gender : undefined,
+        grip_form: (gripForm && gripForm !== '未設定') ? gripForm : undefined,
+        physique: (physique && physique !== '未設定') ? physique : undefined,
+        frequency: (frequency && frequency !== '未設定') ? frequency : undefined,
+        play_style: (playStyle && playStyle !== '未設定') ? playStyle : undefined,
+        favarit_shot: (favaritShot && favaritShot !== '未設定') ? favaritShot : undefined,
+        weak_shot: (weakShot && weakShot !== '未設定') ? weakShot : undefined,
+      }
+    }).then((res) => {
+      closeReviewSearchModal();
+
+      setReviewsPaginator(res.data)
+
+      setReviews(res.data.data);
+
+      console.log('検索完了しました');
+    }).catch(e => {
+      console.log(e);
+    })
   }
+
+  const allSearchStateReset = () => {
+    resetSearchStateOfEvaluations();
+    resetSearchStateOfTools();
+    resetSearchStateOfUserStatus();
+
+    getReviewsList();
+    // closeReviewSearchModal();
+  }
+
+  const resetSearchStateOfEvaluations = () => {
+    setMatchRate(1);
+    setPysicalDurability(1);
+    setPerformanceDurability(1);
+  }
+
+  const resetSearchStateOfTools = () => {
+    setStringingWay('未設定');
+    setRacket(undefined);
+    setMainGut(undefined);
+    setCrossGut(undefined);
+  }
+
+  const resetSearchStateOfUserStatus = () => {
+    setExperiencePeriod(undefined);
+    setFrequency('未設定');
+    setPlayStyle('未設定');
+    setGripForm('未設定');
+    setFavaritShot('未設定');
+    setWeakShot('未設定');
+    setAge('未設定');
+    setGender('未設定');
+    setHeight('未設定');
+    setPhysique('未設定');
+  }
+
+  const resetExperiencePeriod = () => {
+    setExperiencePeriod(undefined);
+  }
+
 
   return (
     <>
       <AuthCheck>
         {isAuth && (
           <>
-            {/* <div className="container mx-auto relative"> */}
             <div className="container mx-auto">
               <div className="mb-6 mt-6 italic md:mb-[32px] md:mt-[32px]">
                 <h1 className="text-center text-[20px] md:text-[32px]">Reviews</h1>
@@ -452,21 +542,30 @@ const ReviewList = () => {
               {/* review検索モーダル */}
               <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 z-30 ${reviewSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
                 <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                  <div onClick={closeReviewSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                  <div onClick={closeReviewSearchModal} className="self-end hover:cursor-pointer mb-2 ">
                     <IoClose size={48} />
                   </div>
 
-                  {/* <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]"> */}
-                  {/* <form action="" onSubmit={searchReview} className="mb-[24px] md:flex md:mb-[40px]"> */}
-                  <form action="" onSubmit={searchReview} className="flex flex-col mb-[24px] md:flex-row md:justify-center md:gap-x-[48px] md:flex-wrap md:mb-[40px]">
+                  <div className="flex justify-end w-[100%] max-w-[320px] mb-4 md:max-w-[784px] md:mx-auto md:justify-start">
+                    <button
+                      onClick={allSearchStateReset}
+                      className="text-white text-[14px] w-[120px] h-6 rounded  bg-sub-green md:w-[104px] md:h-8"
+                    >全てリセット</button>
+                  </div>
+
+                  <form action="" onSubmit={searchReviews} className="flex flex-col mb-[24px] md:flex-row md:justify-center md:gap-x-[48px] md:flex-wrap md:mb-[40px]">
+                    {/* section-two */}
                     <div className="w-[100%] max-w-[320px] mb-6 md:max-w-[360px]">
-                      <div className="w-[100%] max-w-[320px] mb-6 md:max-w-[360px]">
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
                         <SubHeading text='評価' className="text-[16px] md:text-[18px] md:mb-2" />
                         <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
                       </div>
 
+
                       {/* 評価値 */}
-                      <div className="w-[320px]">
+                      <div className="w-[320px] mb-6">
+                        <p className="text-[12px] text-right mb-1">※ 評価値以上で検索されます</p>
+
                         <EvaluationRangeItem
                           labelText="自分に合っているか"
                           scale={true}
@@ -509,16 +608,12 @@ const ReviewList = () => {
                           id="stringing_way"
                           value={stringingWay}
                           onChange={onChangeInputStringingWay}
-                          // disabled={!!myEquipment}
                           className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
                         >
+                          <option value="未設定" >未設定</option>
                           <option value="single" >単張り</option>
                           <option value="hybrid" >ハイブリッド</option>
                         </select>
-
-                        {/* {errors.stringing_way.length !== 0 &&
-                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                        } */}
                       </div>
 
                       <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
@@ -559,7 +654,7 @@ const ReviewList = () => {
                         <TextUnderBar className="w-[100%] max-w-[80px] md:max-w-[96px]" />
                       </div>
 
-                      <div className="mb-4">
+                      <div className="mb-10">
                         <SelectedToolWithoutImage
                           tool={racket}
                           type='racket'
@@ -573,15 +668,16 @@ const ReviewList = () => {
                     {/* section-two */}
                     {/* ユーザーステータスでの検索項目 */}
                     <div className="">
-                      <div className="w-[100%] max-w-[320px] mb-4 mt-[40px] md:mt-0 md:max-w-[360px]">
+                      <div className="w-[100%] max-w-[320px] mb-4 md:mt-0 md:max-w-[360px]">
                         <SubHeading text='ユーザーステータス' className="text-[16px] md:text-[18px] md:mb-2" />
                         <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
                       </div>
 
-                      <div className="mb-6">
+                      {/* <div className="flex flex-wrap mb-6 w-[100%] max-w-[320px] md:max-w-[360px]"> */}
+                      <div className="flex flex-wrap mb-4 w-[100%] max-w-[320px] md:max-w-[360px]">
                         <label
                           htmlFor="experience_period"
-                          className="block text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-2"
+                          className="block text-[14px] h-[16px] mb-1 basis-[320px] md:text-[16px] md:h-[18px] md:mb-2"
                         >テニス歴</label>
 
                         <input
@@ -590,140 +686,115 @@ const ReviewList = () => {
                           onChange={onChangeExperiencePeriod}
                           min="0"
                           max="100"
-                          defaultValue={experiencePeriod}
+                          value={experiencePeriod === undefined ? '' : experiencePeriod}
                           className="border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green"
                         />
-                        <span className="ml-4">年</span>
+                        <span className="ml-4 h-10 leading-10">年</span>
 
-                        {/* {errors.experience_period.length !== 0 &&
-                        errors.experience_period.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
+                        <button
+                          type="button"
+                          onClick={resetExperiencePeriod}
+                          className="text-white text-[14px] w-[80px] h-6 rounded ml-auto bg-sub-green md:w-[104px] md:h-8"
+                        >リセット</button>
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="テニス頻度"
                           type="frequency"
                           onChangeHandler={onChangeFrequency}
                           optionValues={frequencys}
+                          value={frequency}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="プレースタイル"
                           type="play_style"
                           onChangeHandler={onChangePlayStyle}
                           optionValues={playStyles}
+                          value={playStyle}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="グリップの握り方"
                           type="grip_form"
                           onChangeHandler={onChangeGripForm}
                           optionValues={gripForms}
+                          value={gripForm}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="好きなショット"
                           type="favarit_shot"
                           onChangeHandler={onChangeFavaritShot}
                           optionValues={favaritShots}
+                          value={favaritShot}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="苦手なショット"
                           type="weak_shot"
                           onChangeHandler={onChangeWeakShot}
                           optionValues={weakShots}
+                          value={weakShot}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="年齢"
                           type="age"
                           onChangeHandler={onChangeAge}
                           optionValues={ages}
+                          value={age}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="性別"
                           type="gender"
                           onChangeHandler={onChangeGender}
                           optionValues={genders}
+                          value={gender}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="背丈"
                           type="height"
                           onChangeHandler={onChangeHeight}
                           optionValues={heights}
+                          value={height}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
 
-                      <div className=" mb-8">
+                      <div className="mb-4">
                         <SelectBox
                           labelText="体格"
                           type="physique"
                           onChangeHandler={onChangePhysique}
                           optionValues={physiques}
+                          value={physique}
                           className="w-80 md:w-[360px] h-10"
                         />
-
-                        {/* {errors.frequency.length !== 0 &&
-                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
-                      } */}
                       </div>
                     </div>
 

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -8,6 +8,13 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import Pagination, { Paginator } from "@/components/Pagination";
 import BarGraph, { EvaluationVal } from "@/components/BarGraph";
+import { IoClose } from "react-icons/io5";
+import EvaluationRangeItem from "@/components/EvaluationRangeItem";
+import SubHeading from "@/components/SubHeading";
+import TextUnderBar from "@/components/TextUnderBar";
+import SelectedToolWithoutImage from "@/components/SelectedToolWithoutImage";
+import useTennisProfileForm from "@/hooks/useTennisProfileForm";
+import SelectBox from "@/components/SelectBox";
 
 type GutImage = {
   id: number,
@@ -78,7 +85,54 @@ const ReviewList = () => {
 
   const [reviewsPaginator, setReviewsPaginator] = useState<Paginator<Review>>();
 
-  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
+  const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/';
+
+  const {
+    // state値
+    experiencePeriod,
+    frequency,
+    playStyle,
+    gripForm,
+    favaritShot,
+    weakShot,
+    age,
+    gender,
+    height,
+    physique,
+
+    // setState関数
+    onChangeExperiencePeriod,
+    onChangeFrequency,
+    onChangePlayStyle,
+    onChangeGripForm,
+    onChangeFavaritShot,
+    onChangeWeakShot,
+    onChangeAge,
+    onChangeGender,
+    onChangeHeight,
+    onChangePhysique,
+
+    // リテラル型のユニオンにある値を配列で表したもの
+    frequencys,
+    playStyles,
+    gripForms,
+    favaritShots,
+    weakShots,
+    ages,
+    genders,
+    heights,
+    physiques,
+  } = useTennisProfileForm();
+  console.log('experiencePeriod', experiencePeriod)
+  console.log('frequency', frequency)
+  console.log('playStyle', playStyle)
+  console.log('favaritShot', favaritShot)
+  console.log('gripForm', gripForm)
+  console.log('age', age)
+  console.log('weakShot', weakShot)
+  console.log('gender', gender)
+  console.log('height', height)
+  console.log('physique', physique)
 
   //ページネーションを考慮したreview一覧データの取得関数
   const getReviewsList = async (url: string = 'api/gut_reviews') => {
@@ -97,20 +151,79 @@ const ReviewList = () => {
     }
   }, [])
 
+  // 評価に関するstate
+  const [matchRate, setMatchRate] = useState<number>(3);
+  console.log('matchRate', matchRate)
+  const [pysicalDurability, setPysicalDurability] = useState<number>(3);
+  console.log('pysicalDurability', pysicalDurability)
+  const [performanceDurability, setPerformanceDurability] = useState<number>(3);
+  console.log('performanceDurability', performanceDurability)
+
+  //モーダルの開閉に関するstate
+  const [reviewSearchModalVisibility, setReviewSearchModalVisibility] = useState<boolean>(false);
+
+  const [reviewSearchModalVisibilityClassName, setReviewSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+
+  // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
+  useEffect(() => {
+    if (reviewSearchModalVisibility) {
+      setReviewSearchModalVisibilityClassName('opacity-100 scale-100')
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      setReviewSearchModalVisibilityClassName('opacity-0 scale-0');
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [reviewSearchModalVisibility])
+
+  //モーダルの開閉
+  const closeReviewSearchModal = () => {
+    setReviewSearchModalVisibility(false);
+    setReviewSearchModalVisibilityClassName('opacity-0 scale-0')
+  }
+
+  const openReviewSearchModal = () => {
+    setReviewSearchModalVisibility(true);
+    setReviewSearchModalVisibilityClassName('opacity-100 scale-100')
+  }
+
+  const [stringingWay, setStringingWay] = useState<string>('single');
+  console.log('stringingWay', stringingWay)
+
+  //inputの制御関数群
+  const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setStringingWay(e.target.value);
+    // setCrossGut(undefined);
+  }
+
+  const searchReview = () => {
+
+  }
+
   return (
     <>
       <AuthCheck>
         {isAuth && (
           <>
+            {/* <div className="container mx-auto relative"> */}
             <div className="container mx-auto">
               <div className="mb-6 mt-6 italic md:mb-[32px] md:mt-[32px]">
                 <h1 className="text-center text-[20px] md:text-[32px]">Reviews</h1>
               </div>
 
               <div className="flex justify-center mb-6 md:w-[784px] md:mx-auto md:justify-end">
-                <button className="text-white text-[14px] w-[264px] h-8 rounded  bg-sub-green md:w-[104px]">検索</button>
+                <button
+                  onClick={openReviewSearchModal}
+                  className="text-white text-[14px] w-[264px] h-8 rounded  bg-sub-green md:w-[104px]"
+                >検索</button>
               </div>
-
+              
               <div className="flex flex-col items-center md:flex-row md:flex-wrap md:w-[784px] md:justify-between md:mx-auto">
                 {reviews && (
                   reviews.map(review => {
@@ -264,6 +377,293 @@ const ReviewList = () => {
                 paginate={getReviewsList}
                 className="mt-[32px] md:mt-[48px]"
               />
+
+              {/* review検索モーダル */}
+              <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 z-30 ${reviewSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
+                <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                  <div onClick={closeReviewSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
+                    <IoClose size={48} />
+                  </div>
+
+                  {/* <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]"> */}
+                  {/* <form action="" onSubmit={searchReview} className="mb-[24px] md:flex md:mb-[40px]"> */}
+                  <form action="" onSubmit={searchReview} className="flex flex-col mb-[24px] md:flex-row md:justify-center md:gap-x-[48px] md:flex-wrap md:mb-[40px]">
+                    <div className="w-[100%] max-w-[320px] mb-6 md:max-w-[360px]">
+                      <div className="w-[100%] max-w-[320px] mb-6 md:max-w-[360px]">
+                        <SubHeading text='評価' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      {/* 評価値 */}
+                      <div className="w-[320px]">
+                        <EvaluationRangeItem
+                          labelText="自分に合っているか"
+                          scale={true}
+                          onChangeInputRangeHnadler={(e) => { setMatchRate(Number(e.target.value)) }}
+                          valueState={matchRate}
+                          className="mb-6 md:mb-2"
+                          trackColor="[&::-webkit-slider-runnable-track]:bg-white [&::-moz-range-track]:bg-white"
+                        />
+
+                        <EvaluationRangeItem
+                          labelText="切れにくさ"
+                          scale={false}
+                          onChangeInputRangeHnadler={(e) => { setPysicalDurability(Number(e.target.value)) }}
+                          valueState={pysicalDurability}
+                          className="mb-[41px] md:mb-[36px]"
+                          trackColor="[&::-webkit-slider-runnable-track]:bg-white [&::-moz-range-track]:bg-white"
+                        />
+
+                        <EvaluationRangeItem
+                          labelText="打球感の持続"
+                          scale={false}
+                          onChangeInputRangeHnadler={(e) => { setPerformanceDurability(Number(e.target.value)) }}
+                          valueState={performanceDurability}
+                          className="mb-10"
+                          trackColor="[&::-webkit-slider-runnable-track]:bg-white [&::-moz-range-track]:bg-white"
+                        />
+                      </div>
+
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='装備構成' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      {/* 張り方選択 */}
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <label htmlFor="stringing_way" className="block text-[14px] md:text-[16px]">ストリングの張り方</label>
+
+                        <select
+                          name="stringing_way"
+                          id="stringing_way"
+                          value={stringingWay}
+                          onChange={onChangeInputStringingWay}
+                          // disabled={!!myEquipment}
+                          className="border border-gray-300 rounded w-[160px] h-10 p-2 focus:outline-sub-green"
+                        >
+                          <option value="single" >単張り</option>
+                          <option value="hybrid" >ハイブリッド</option>
+                        </select>
+
+                        {/* {errors.stringing_way.length !== 0 &&
+                          errors.stringing_way.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                        } */}
+                      </div>
+
+                      <div className="w-[100%] max-w-[320px] mb-4 md:max-w-[360px]">
+                        <SubHeading text='ストリング' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[80px] md:max-w-[96px]" />
+                      </div>
+
+                      <div className="mb-4">
+                        {stringingWay === 'hybrid' && <p className="text-[14px] h-[16px] mb-2 leading-[16px] md:text-[16px] md:h-[18px]">クロス</p>}
+
+                        <SelectedToolWithoutImage
+                          // tool={}
+                          type='gut'
+                          selectBtnVisible={true}
+                          btnText="選ぶ"
+                        // btnClickHandler={}
+                        />
+                      </div>
+
+                      {stringingWay === 'hybrid' && (
+                        <>
+                          <div className="">
+                            <p className="text-[14px] h-[16px] mb-2 leading-[16px] md:text-[16px] md:h-[18px]">メイン</p>
+
+                            <SelectedToolWithoutImage
+                              // tool={}
+                              type='gut'
+                              selectBtnVisible={true}
+                              btnText="選ぶ"
+                            // btnClickHandler={}
+                            />
+                          </div>
+                        </>
+                      )}
+
+                      <div className="w-[100%] max-w-[320px] mb-4 mt-6 md:max-w-[360px]">
+                        <SubHeading text='ラケット' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[80px] md:max-w-[96px]" />
+                      </div>
+
+                      <div className="mb-4">
+                        <SelectedToolWithoutImage
+                          // tool={}
+                          type='racket'
+                          selectBtnVisible={true}
+                          btnText="選ぶ"
+                        // btnClickHandler={}
+                        />
+                      </div>
+                    </div>
+
+                    {/* section-two */}
+                    {/* ユーザーステータスでの検索項目 */}
+                    <div className="">
+                      <div className="w-[100%] max-w-[320px] mb-4 mt-[40px] md:mt-0 md:max-w-[360px]">
+                        <SubHeading text='ユーザーステータス' className="text-[16px] md:text-[18px] md:mb-2" />
+                        <TextUnderBar className="w-[100%] max-w-[320px] md:max-w-[360px]" />
+                      </div>
+
+                      <div className="mb-6">
+                        <label
+                          htmlFor="experience_period"
+                          className="block text-[14px] h-[16px] mb-1 md:text-[16px] md:h-[18px] md:mb-2"
+                        >テニス歴</label>
+
+                        <input
+                          type="number"
+                          name="experience_period"
+                          onChange={onChangeExperiencePeriod}
+                          min="0"
+                          max="100"
+                          defaultValue={experiencePeriod}
+                          className="border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green"
+                        />
+                        <span className="ml-4">年</span>
+
+                        {/* {errors.experience_period.length !== 0 &&
+                        errors.experience_period.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="テニス頻度"
+                          type="frequency"
+                          onChangeHandler={onChangeFrequency}
+                          optionValues={frequencys}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="プレースタイル"
+                          type="play_style"
+                          onChangeHandler={onChangePlayStyle}
+                          optionValues={playStyles}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="グリップの握り方"
+                          type="grip_form"
+                          onChangeHandler={onChangeGripForm}
+                          optionValues={gripForms}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="好きなショット"
+                          type="favarit_shot"
+                          onChangeHandler={onChangeFavaritShot}
+                          optionValues={favaritShots}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="苦手なショット"
+                          type="weak_shot"
+                          onChangeHandler={onChangeWeakShot}
+                          optionValues={weakShots}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="年齢"
+                          type="age"
+                          onChangeHandler={onChangeAge}
+                          optionValues={ages}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="性別"
+                          type="gender"
+                          onChangeHandler={onChangeGender}
+                          optionValues={genders}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="背丈"
+                          type="height"
+                          onChangeHandler={onChangeHeight}
+                          optionValues={heights}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+
+                      <div className=" mb-8">
+                        <SelectBox
+                          labelText="体格"
+                          type="physique"
+                          onChangeHandler={onChangePhysique}
+                          optionValues={physiques}
+                          className="w-80 md:w-[360px] h-10"
+                        />
+
+                        {/* {errors.frequency.length !== 0 &&
+                        errors.frequency.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                      } */}
+                      </div>
+                    </div>
+
+
+                    <div className="flex justify-center md:justify-start sticky md:self-end bottom-8 z-40">
+                      <button type="submit" className="text-white font-bold text-[14px] w-[320px] h-8 rounded  bg-sub-green md:text-[16px] md:h-[40px] md:w-[280px]">検索する</button>
+                    </div>
+                  </form>
+
+                </div>
+              </div>
             </div>
           </>
         )}

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -16,6 +16,7 @@ import SelectedToolWithoutImage from "@/components/SelectedToolWithoutImage";
 import useTennisProfileForm from "@/hooks/useTennisProfileForm";
 import SelectBox from "@/components/SelectBox";
 import GutSearchModal from "@/components/GutSearchModal";
+import RacketSearchModal from "@/components/RacketSearchModal";
 
 type GutImage = {
   id: number,
@@ -140,6 +141,8 @@ const ReviewList = () => {
   // 各種検索結果state
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
 
+  const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
+
   const [witchSelectingGut, setWitchSelectingGut] = useState<string>('');
   console.log('witchSelectingGut', witchSelectingGut)
 
@@ -181,6 +184,8 @@ const ReviewList = () => {
   const [reviewSearchModalVisibilityClassName, setReviewSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   const [gutSearchModalVisibility, setGutSearchModalVisibility] = useState<boolean>(false);
+
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
 
   // review検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
@@ -239,6 +244,17 @@ const ReviewList = () => {
     setWitchSelectingGut('');
   }
 
+  // racket検索モーダル関連
+  const closeRacketSearchModalHandler = () => {}
+
+  const openRacketSearchModal = () => {
+    setRacketSearchModalVisibility(true);
+  }
+
+  const selectRacketHandler = (racket: Racket) => {
+    setRacket(racket);
+  }
+
   const [stringingWay, setStringingWay] = useState<string>('single');
   console.log('stringingWay', stringingWay)
 
@@ -247,6 +263,9 @@ const ReviewList = () => {
 
   const [crossGut, setCrossGut] = useState<Gut>();
   console.log('crossGut', crossGut)
+
+  const [racket, setRacket] = useState<Racket>();
+  console.log('racket', racket)
 
   //inputの制御関数群
   const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -542,11 +561,11 @@ const ReviewList = () => {
 
                       <div className="mb-4">
                         <SelectedToolWithoutImage
-                          // tool={}
+                          tool={racket}
                           type='racket'
                           selectBtnVisible={true}
                           btnText="選ぶ"
-                        // btnClickHandler={}
+                          btnClickHandler={openRacketSearchModal}
                         />
                       </div>
                     </div>
@@ -726,6 +745,18 @@ const ReviewList = () => {
                 showingResult={true}
                 searchedGuts={searchedGuts}
                 setSearchedGuts={setSearchedGuts}
+                zIndexClassName="z-50"
+              />
+
+              <RacketSearchModal
+                modalVisibility={racketSearchModalVisibility}
+                setModalVisibility={setRacketSearchModalVisibility}
+                makers={makers}
+                closeModalHandler={closeRacketSearchModalHandler}
+                selectRacketHandler={selectRacketHandler}
+                showingResult={true}
+                searchedRackets={searchedRackets}
+                setSearchedRackets={setSearchedRackets}
                 zIndexClassName="z-50"
               />
 


### PR DESCRIPTION
_**issue:**_ #96 

_**背景：**_
gut レビュー一覧ページには検索モーダルがなく検索機能を利用できない状態である

_**確認手順**_

- [ ] userでログインする
- [ ] gutレビュー一覧ページに遷移する
- [ ] 検索モーダルがなく検索ができない状態であることが確認できる

_**やったこと：**_

- [ ] review検索モーダルのレイアウトの作成
- [ ] review検索モーダルから開くgut検索モーダルの実装
    - GutSearchModalコンポーネントを作成、利用
- [ ] review検索モーダルから開くracket検索モーダルの実装
    - RacketSearchModalコンポーネントを作成、利用
- [ ] gutレビュー検索処理の実装

_**備考：**_
１ファイルのコード量が多くなってきていたため、各モーダルをコンポーネント化したり、src/hooks/useTennisProfileForm.tsを作成し、tennisProfileを扱うform関連の機能コードをカスタムhooksに切り出してある。
各モーダルコンポーネントの大まかな使用方は同ファイル上部にコメントで記載してある。

レビューお願いします