### PR TITLE
modify: 各種一覧ページにてスクロールバーが２本表示されて挙動がおかしかったことへの対処

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,10 +2,10 @@ import { Html, Head, Main, NextScript } from 'next/document'
 
 export default function Document() {
   return (
-    <Html lang="en" className='text-[16px] tracking-wide overflow-auto'>
+    <Html lang="en" className='text-[16px] tracking-wide'>
       <Head />
-      <body>
-        <div className='overflow-x-hidden min-h-screen relative'>
+      <body className='overflow-hidden'>
+        <div className='overflow-hidden min-h-screen relative'>
           <Main />
           <NextScript />
         </div>


### PR DESCRIPTION
_**issue:**_ #83

_**背景：**_
gut及びracket、review一覧画面、でスクロールバーが2本表示されてしまっている

_**確認手順：**_

- [ ] userもしくはadminでログイン
- [ ] gut一覧ページに遷移
- [ ] スクロールバーが2本表示されているのが確認できる
- [ ] racket一覧ページも同様
- [ ] review一覧ページも同様

<img width="1440" alt="スクリーンショット 2024-01-17 午後7 26 23" src="https://github.com/ryuichi-works/strii-frontend/assets/58509835/bd653431-67e3-4975-b0e7-c54ab7aae068">

_**わかった原因：**_
spサイズのheaderメニューを右側に飛ばしてハンバーガーメニューとして動作させているために、bodyタグにoverflow-x: hiddenをつけているが、これを単にoverflow:hiddenに変えることでスクロール動作が直ることをchrome検証ツールより確認。

_**やったこと：**_

- [ ] <html>,<body>タグなどのoverflowが原因で起こっていたので、bodyタグおよび直下のdivタグにoverflow:hiddenとなる様にtailwindのクラスを指定した。
- [ ] tailwindでnextのコンポーネント<Html>に対してoverflowに指定が反映されていなかったのでoverflowプロパティーは削除した

結果：
<img width="1440" alt="スクリーンショット 2024-01-17 午後7 30 04" src="https://github.com/ryuichi-works/strii-frontend/assets/58509835/08e53d5f-e99e-44ea-b891-2dd82928e047">


_**備考：**_
別画面で使用している検索モーダルの開閉時に背景スクロール動作の抑制のため、<html>,<body>タグのoverflowプロパティーをauto,hiddenでトグルさせているので注意されたし。

レビューお願いします