### PR TITLE
modify: gut一覧から詳細ページに移りブラウザバックで一覧へ戻った時の検索状態などを維持できる様に修正

### DIFF
--- a/src/components/ContextProvidor.tsx
+++ b/src/components/ContextProvidor.tsx
@@ -1,0 +1,24 @@
+import { AuthContextProvidor } from "@/context/AuthContext";
+import { GutContextProvider } from "@/context/GutContext";
+import { HistoryContextProvider } from "@/context/HistoryContext";
+import React, { ReactNode } from "react";
+
+type ContextProvidor = {
+  children: ReactNode
+}
+
+const ContextProvidor: React.FC<ContextProvidor> = ({ children }) => {
+  return (
+    <>
+      <HistoryContextProvider>
+        <AuthContextProvidor>
+          <GutContextProvider>
+            {children}
+          </GutContextProvider>
+        </AuthContextProvidor>
+      </HistoryContextProvider>
+    </>
+  );
+}
+
+export default ContextProvidor;

--- a/src/context/GutContext.tsx
+++ b/src/context/GutContext.tsx
@@ -1,0 +1,65 @@
+import { Paginator } from "@/components/Pagination";
+import { Gut } from "@/pages/reviews";
+import React, { ReactNode, createContext, useState } from "react";
+
+type ContextVals = {
+  gutsPaginator: Paginator<Gut> | undefined,
+  setGutsPaginator: React.Dispatch<React.SetStateAction<Paginator<Gut> | undefined>>,
+  guts: Gut[] | undefined,
+  setGuts: React.Dispatch<React.SetStateAction<Gut[] | undefined>>,
+  inputSearchWord: string,
+  setInputSearchWord: React.Dispatch<React.SetStateAction<string>>,
+  inputSearchMaker: number | undefined,
+  setInputSearchMaker: React.Dispatch<React.SetStateAction<number | undefined>>,
+}
+
+const initialContextVals = {
+  gutsPaginator: undefined,
+  setGutsPaginator:  () => { },
+  guts: undefined,
+  setGuts: () => { },
+  inputSearchWord: '',
+  setInputSearchWord:  () => { },
+  inputSearchMaker: undefined,
+  setInputSearchMaker: () => { },
+}
+
+const GutContext = createContext<ContextVals>(initialContextVals);
+
+type Props = {
+  children: ReactNode
+}
+
+const GutContextProvider: React.FC<Props> = ({ children }) => {
+  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
+  const [guts, setGuts] = useState<Gut[]>();
+
+  //検索関連のstate
+  const [inputSearchWord, setInputSearchWord] = useState<string>('');
+
+  const [inputSearchMaker, setInputSearchMaker] = useState<number>();
+
+  const contextVals = {
+    gutsPaginator,
+    setGutsPaginator,
+    guts,
+    setGuts,
+    inputSearchWord,
+    setInputSearchWord,
+    inputSearchMaker,
+    setInputSearchMaker,
+  }
+
+  return (
+    <>
+      <GutContext.Provider value={contextVals} >
+        {children}
+      </GutContext.Provider>
+    </>
+  );
+}
+
+export {
+  GutContextProvider,
+  GutContext
+}

--- a/src/context/HistoryContext.tsx
+++ b/src/context/HistoryContext.tsx
@@ -1,0 +1,51 @@
+import { useRouter } from "next/router";
+import React, {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState
+} from "react";
+
+const HistoryContext = createContext(['']);
+
+type Props = {
+  children: ReactNode
+}
+
+const HistoryContextProvider: React.FC<Props> = ({ children }) => {
+  const router = useRouter();
+
+  // コンポーネントが初回評価されるタイミングとhistoryのstateが更新完了されるタイミングが
+  // historyのstate更新が後になりワンテンポずれるので、使用先の初回レンダリングの過程でhistory stateを使用する際は
+  // 初回レンダリングが完了していない間は前ページでのstateの状態なので注意して使用されたし
+  // 具体的に
+  // 初回レンダリングの過程ではstateが更新される前となるため、配列の左から[直前のpath, 2つ前のpath, 3つ前のpath]
+  // 初回レンダリング後ではstate更新後なので、配列の左から[現在のpath, 直前のpath, 2つ前のpath]
+  // を意味する様になるので注意されたし。
+  const [history, setHistory] = useState<string[]>([router.asPath, '', '']);
+
+  useEffect(() => {
+    setHistory([router.asPath, history[0], history[1]]);
+  }, [router.asPath]);
+
+  return (
+    <>
+      <HistoryContext.Provider value={history}>
+        {children}
+      </HistoryContext.Provider>
+    </>
+  );
+}
+
+const usePathHistory = () => {
+  const history = useContext(HistoryContext)
+
+  return history;
+}
+
+export {
+  HistoryContextProvider,
+  HistoryContext,
+  usePathHistory,
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,15 +1,15 @@
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
-import { AuthContextProvidor } from '@/context/AuthContext'
 import Header from '@/components/layouts/header';
+import ContextProvidor from '@/components/ContextProvidor';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
-      <AuthContextProvidor>
-          <Header/>
-          <Component {...pageProps} />
-      </AuthContextProvidor>
+      <ContextProvidor>
+        <Header />
+        <Component {...pageProps} />
+      </ContextProvidor>
     </>
   );
   // return <Component {...pageProps} />

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -1,6 +1,7 @@
 import type { Gut } from "../reviews";
 import type { Maker } from "../users/[id]/profile";
 import React, { useContext, useEffect, useState } from "react";
+// import { useRouter } from "next/navigation";
 import { useRouter } from "next/router";
 import axios from "@/lib/axios";
 import { AuthContext } from "@/context/AuthContext";
@@ -11,26 +12,33 @@ import TextUnderBar from "@/components/TextUnderBar";
 import PrimaryHeading from "@/components/PrimaryHeading";
 import { Adamina } from "next/font/google";
 import { IoClose } from "react-icons/io5";
-import Pagination, {type Paginator } from "@/components/Pagination";
+import Pagination, { type Paginator } from "@/components/Pagination";
+import { GutContext } from "@/context/GutContext";
+import { usePathHistory } from "@/context/HistoryContext";
 
 const GutList = () => {
   const router = useRouter();
 
+  const [, lastBeforePath] = usePathHistory();
+
   const { isAuth, user, setUser, setIsAuth, admin, isAuthAdmin } = useContext(AuthContext);
 
-  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
+  const {
+    gutsPaginator,
+    setGutsPaginator,
+    guts,
+    setGuts,
+    inputSearchWord,
+    setInputSearchWord,
+    inputSearchMaker,
+    setInputSearchMaker,
+  } = useContext(GutContext);
 
-  const [guts, setGuts] = useState<Gut[]>();
-  console.log('guts', guts)
+  console.log('inputSearchMaker', inputSearchMaker)
 
   const [makers, setMakers] = useState<Maker[]>();
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
-
-  //検索関連のstate
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
 
   //モーダルの開閉に関するstate
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
@@ -38,7 +46,6 @@ const GutList = () => {
   //ページネーションを考慮したgut一覧データの取得関数
   const getGutsList = async (url: string = 'api/guts') => {
     await axios.get(url).then(res => {
-      console.log('res', res.data)
       setGutsPaginator(res.data)
       setGuts(res.data.data);
     })
@@ -54,7 +61,14 @@ const GutList = () => {
 
       getMakerList();
 
-      getGutsList();
+      let isVisitingByHistoryBack = router.asPath === lastBeforePath;
+
+      if (!guts || !isVisitingByHistoryBack) {
+        getGutsList();
+        setInputSearchWord('');
+        setInputSearchMaker(undefined);
+      }
+
     } else {
       router.push('/users/login');
     }
@@ -62,7 +76,7 @@ const GutList = () => {
 
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
+      setInputSearchMaker(undefined);
       return
     };
 
@@ -121,13 +135,25 @@ const GutList = () => {
                   <form action="" onSubmit={searchGuts} className=" flex">
                     <div className="mb-6 md:mb-0 md:mr-[16px]">
                       <label htmlFor="name_ja" className="block text-[16px] mb-2 pl-1 h-[18px]">ストリング検索ワード</label>
-                      <input type="text" name="name_ja" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                      <input
+                        type="text"
+                        name="name_ja"
+                        defaultValue={inputSearchWord}
+                        onChange={(e) => setInputSearchWord(e.target.value)}
+                        className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
+                      />
                     </div>
 
                     <div className="mb-8 md:mb-0 md:mr-[24px]">
                       <label htmlFor="maker" className="block text-[16px] mb-2 pl-1  h-[18px]">メーカー</label>
 
-                      <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                      <select
+                        name="maker"
+                        id="maker"
+                        value={inputSearchMaker ? inputSearchMaker : '未選択'}
+                        onChange={(e) => { onChangeInputSearchMaker(e) }}
+                        className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
+                      >
                         <option value="未選択" selected>未選択</option>
                         {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
                       </select>
@@ -176,13 +202,25 @@ const GutList = () => {
                 <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
                   <div className="mb-6 md:mb-0 md:mr-[16px]">
                     <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング検索ワード</label>
-                    <input type="text" name="name_ja" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+                    <input
+                      type="text"
+                      name="name_ja"
+                      defaultValue={inputSearchWord}
+                      onChange={(e) => setInputSearchWord(e.target.value)}
+                      className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
+                    />
                   </div>
 
                   <div className="mb-8 md:mb-0 md:mr-[24px]">
                     <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
 
-                    <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+                    <select
+                      name="maker"
+                      id="maker"
+                      value={inputSearchMaker ? inputSearchMaker : '未選択'}
+                      onChange={(e) => { onChangeInputSearchMaker(e) }}
+                      className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
+                    >
                       <option value="未選択" selected>未選択</option>
                       {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
                     </select>


### PR DESCRIPTION
### _issue_
#54 

### _背景：_
gut一覧ページにて検索をかけた後の検索結果から詳細ページへ遷移した後、ブラウザバックで一覧ページに戻ると検索がリセットされて検索前の全件表示されてしまっている。

### _確認・再現手順：_

- [ ] ユーザーでログインする
- [ ] gut一覧ページに遷移
- [ ] 検索をかける
- [ ] 検索結果から一つクリックし詳細画面に遷移
- [ ] ブラウザバックで一覧ページに戻る
- [ ] 先ほどの検索がリセットされていることが確認できる

### _理想：_
検索をかけて詳細画面へ遷移後、一覧ページに戻ると検索項目と検索結果が保持されている。
ページネーションも維持されている

### _やったこと_

- [ ] gut一覧から詳細ページに移りブラウザバックで一覧へ戻った時の検索状態などを維持できる様に修正
修正にあたって

- [ ] gutsページで定義していたstateを一部グローバルで管理するため、コンテキストとしてGutContext.tsxに切り出し
- [ ] 各コンテキストのproviderコンポーネントを読み込むContextProviderコンポーネントを作成しcontextのProviderコンポーネントを１ファイル内で読み込む様に修正
- [ ] ページ遷移のpathの履歴を追える様に、HistoryContextを作成しuseRouterとuseStateを使ってpathの履歴を記録するHistoryContextを作成
    - ブラウザバックを認識させるためにはページ遷移のpathの履歴を参照する必要があった

- [ ] gut一覧ページにて、初回レンダリングのuseEffect内でHistoryContextによって追跡されていたpathで、ブラウザバックしてきた場合は2つ前のpathと現在のpathが一致した場合にブラウザバックしたという判定になる様に修正
- [ ] ブラウザバックしてきた場合はグローバルで管理しているstateを更新せずにページに反映させることで、検索後に詳細ページに遷移しブラウザバックした時でも検索履歴の状態を保持した表示にすることができた
- [ ] また、ページネーション情報も同様の過程で状態を保持される様になっている
- [ ] 状態の維持による検索欄の中身も維持される様に修正

### 備考：
HistoryContextで3つまでpathを追跡できる様になっているが、**そのstateが更新されるタイミングがcontextが使用されているコンポーネントが初回レンダリング完了した際**であり、初回レンダリング途中の処理、具体的には初回レンダリング時に実行されるuseEffect内ではHistoryContextのstateが更新される前で、ひとつ前のページでのpath履歴のstateとないるので、HistoryContextを使う時にはそのずれを注意されたし。

レビューお願いします