### PR TITLE
modify:#113:カードの情報表示が仮の表示のままで、取得してきたデータを反映していないことへの対処

### DIFF
--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -388,7 +388,7 @@ const ReviewList = () => {
                     return (
                       <>
                         <Link href={`/reviews/${review.id}/review`}>
-                          <div key={review.id} className="w-[360px] h-[280px] border border-gray-400 rounded mb-6 flex flex-col justify-around py-4 hover:cursor-pointer">
+                          <div key={review.id} className="w-[360px] h-[280px] border border-gray-400 rounded-lg mb-6 flex flex-col justify-around py-4 hover:cursor-pointer">
                             {/* 単張りのカード */}
                             {review.my_equipment.stringing_way === "single" && (
                               <>
@@ -415,7 +415,7 @@ const ReviewList = () => {
                                   </div>
 
                                   <div>
-                                    <div className="w-[92px] h-[92px] flex flex-col justify-start items-start mb-10">
+                                    <div className="w-[92px] h-full flex flex-col justify-center items-start">
                                       <div className="w-[92px]">
                                         {review.my_equipment.main_gut.gut_image.file_path
                                           ? <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
@@ -424,13 +424,13 @@ const ReviewList = () => {
                                       </div>
 
                                       <div>
-                                        <p className="h-[10px] text-[10px] mr-auto mb-2">Babolat</p>
-                                        <p className="h-8 text-[14px] mr-auto">RPMブラスト</p>
+                                        <p className="h-[10px] text-[10px] mr-auto mb-2">{review.my_equipment.main_gut.maker.name_ja}</p>
+                                        <p className=" text-[14px] mr-auto">{review.my_equipment.main_gut.name_ja}</p>
                                       </div>
 
                                       <div>
-                                        <p className="h-[12px] text-[10px] mr-auto mb-[4px]">ゲージ：1.25</p>
-                                        <p className="h-[12px] text-[10px] mr-auto">テンション：40</p>
+                                        <p className="h-[12px] text-[10px] mr-auto mb-[4px]">ゲージ：{review.my_equipment.main_gut_guage}</p>
+                                        <p className="h-[12px] text-[10px] mr-auto">テンション：{review.my_equipment.main_gut_tension}</p>
                                       </div>
                                     </div>
                                   </div>
@@ -464,7 +464,7 @@ const ReviewList = () => {
                                   </div>
 
                                   <div className="mr-4">
-                                    <div className="w-[92px] h-[92px] flex flex-col justify-start items-start mb-10">
+                                    <div className="w-[92px] flex flex-col justify-center items-start">
                                       <div className="w-[92px]">
                                         {review.my_equipment.main_gut.gut_image.file_path
                                           ? <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
@@ -473,13 +473,13 @@ const ReviewList = () => {
                                       </div>
 
                                       <div>
-                                        <p className="h-[10px] text-[10px] mr-auto mb-2">Babolat</p>
-                                        <p className="h-8 text-[14px] mr-auto">RPMブラスト</p>
+                                        <p className="h-[10px] text-[10px] mr-auto mb-2">{review.my_equipment.main_gut.maker.name_ja}</p>
+                                        <p className="text-[14px] mr-auto">{review.my_equipment.main_gut.name_ja}</p>
                                       </div>
 
                                       <div>
-                                        <p className="h-[12px] text-[10px] mr-auto mb-[4px]">ゲージ：1.25</p>
-                                        <p className="h-[12px] text-[10px] mr-auto">テンション：40</p>
+                                        <p className="h-[12px] text-[10px] mr-auto mb-[4px]">ゲージ：{review.my_equipment.main_gut_guage}</p>
+                                        <p className="h-[12px] text-[10px] mr-auto">テンション：{review.my_equipment.main_gut_tension}</p>
                                       </div>
                                     </div>
                                   </div>
@@ -487,20 +487,20 @@ const ReviewList = () => {
                                   <div>
                                     <div className="w-[92px] h-[92px] flex flex-col justify-start items-start mb-10">
                                       <div className="w-[92px]">
-                                        {review.my_equipment.main_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
+                                        {review.my_equipment.cross_gut.gut_image.file_path
+                                          ? <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                           : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
                                         }
                                       </div>
 
                                       <div>
-                                        <p className="h-[10px] text-[10px] mr-auto mb-2">Babolat</p>
-                                        <p className="h-8 text-[14px] mr-auto">RPMブラスト</p>
+                                        <p className="h-[10px] text-[10px] mr-auto mb-2">{review.my_equipment.cross_gut.maker.name_ja}</p>
+                                        <p className="h-8 text-[14px] mr-auto">{review.my_equipment.cross_gut.name_ja}</p>
                                       </div>
 
                                       <div>
-                                        <p className="h-[12px] text-[10px] mr-auto mb-[4px]">ゲージ：1.25</p>
-                                        <p className="h-[12px] text-[10px] mr-auto">テンション：40</p>
+                                        <p className="h-[12px] text-[10px] mr-auto mb-[4px]">ゲージ：{review.my_equipment.cross_gut_guage}</p>
+                                        <p className="h-[12px] text-[10px] mr-auto">テンション：{review.my_equipment.cross_gut_tension}</p>
                                       </div>
                                     </div>
                                   </div>


### PR DESCRIPTION
### issue
#113 

### 現状：
gutレビュー一覧画面の情報表示で使っているカード内の情報表示が実装初期に表示させていた仮のもののままになっており、所得してきたデータを表示していない。

### 確認手順:

- [ ] userでログインする
- [ ] review一覧画面に遷移する
- [ ] どれかカードをクリックして詳細ページに遷移する。この時カードに記載してあった情報のメーカー名などを覚えておく
- [ ] 詳細ページに記載してあるメーカー名などが異なっているものがあるのが確認できる。

_**コードで確認**_

- [ ] pages/reviews/index.tsxファイルを確認する
- [ ] review情報を表示するカードのコードの行を見る
- [ ] メーカー名、ストリング名、ゲージ、テンションの表示が取得してきたデータではなく、直接記述してある文字列になっているのが確認できる

### やったこと：

- [ ] 仮のテキストで表示していた部分を取得してきたデータを表示する様に修正
- [ ] 修正に伴い、テキストが長くなった時の改行によるレイアウトのずれを修正した

レビューお願いします