### PR TITLE
add:strii-frontendを単体でdocker化させた

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  web-front:
+    build: ./docker
+    container_name: web-front
+    ports:
+      - 3000:3000
+    volumes:
+      - ./:/app/strii-frontend
+    tty: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20.9.0
+
+RUN apt-get update \
+  # && apt-get install -y git
+  && apt-get -y install git libicu-dev libonig-dev libzip-dev zip unzip locales vim \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && locale-gen en_US.UTF-8 \
+  && localedef -f UTF-8 -i en_US en_US.UTF-8
+
+ENV \
+  # TZ=UTC \
+  TZ=Asia/Tokyo \
+  # locale日本語設定
+  # LANG=ja_JP.UTF-8 \
+  # LANGUAGE=ja_JP:ja 
+  # LC_ALL=ja_JP.UTF-8 
+  LANG=en_US.UTF-8 \
+  LANGUAGE=en_US:en \
+  LC_ALL=en_US.UTF-8 
+
+WORKDIR /app


### PR DESCRIPTION
**issue:**
#117 

**背景：**
strii-frontendとは別にstrii-inflaというレポジトリーでdocker化を実現しているが、strii-inflaではstrii-frontendとstrii-backendのdocker化をおこなっており、デプロイする時にこの3つのリポジトリの関係にきおつける必要があり、手順が複雑になる。
これをフロントとバックエンドの2つでそれぞれdocker-compose.ymlを使って別でdocker化された状態を作りたい。

**確認手順：**
githubのリポジトリ一覧にてstrii-infla, strii-frontend, strii-backendの3つのリポジトリがあることが確認でき、dokcer化をしているのがstrii-inflaリポジトリでおこなっているのが確認できる。

**やったこと：**

- [ ] strii-inflaで管理していたdocker関連のコードをstrii-frontendに移植

**備考：**
動作確認として、ローカルでstrii-frontendをgit cloneして改めて開発環境を作って確認している

レビューお願いします