### PR TITLE
modify: サイト初回アクセス時にしたスクロールができなくなっていることへの対処

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="en" className='text-[16px] tracking-wide'>
       <Head />
-      <body className='overflow-hidden'>
+      <body className='overflow-x-hidden'>
         <div className='overflow-hidden min-h-screen relative'>
           <Main />
           <NextScript />


### PR DESCRIPTION
**issue**
#120 

**背景：**
サイト初回表示時にTopページの縦スクロールが固まってしまっている
また、別ページでもストリング一覧やラケット一覧画面で同様の現象が確認できる

**確認手順：**

- [ ] サイトにリロードなどで初回アクセスする

- [ ] 縦スクロールが無効になっているのが確認できる

- [ ] そのままストリング一覧画面もしくはラケット一覧画面に遷移する同様に縦スクロールが効かないことがわかる

- [ ] また、レビュー一覧画面に遷移すると縦スクロールが復活しており、以後Topページなどに遷移すると縦スクロールが復活しているのが確認できる

**やったこと**

- [ ] _document.tsxに定義してあるbodyタグでtailwindのoverflow-hiddenをoverflow-x-hiddenとしてx方向のみ作用させ、y方向はスクロールかに変更

レビューお願いします