### PR TITLE
modify:#94:spサイズのmenu表示中の背景スクロールを固定させた

### DIFF
--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -1,6 +1,6 @@
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -25,6 +25,22 @@ const Header: React.FC = () => {
     setAdmin,
     setIsAuthAdmin,
   } = useContext(AuthContext);
+
+  // spサイズのmenu表示しに背景スクロールを操作
+  useEffect(() => {
+    if (hamburgerToggle === 'open') {
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+    } else if(hamburgerToggle === 'close') {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.documentElement.style.overflow = 'auto';
+    }
+  }, [hamburgerToggle])
 
   const hamburgerClickHandler = () => {
     if (hamburgerToggle === 'close') {


### PR DESCRIPTION
### issue
#94 

### 背景：
ｓｐサイズでheaderのハンバーガーメニューでスライドメニューを表示した時に縦スクロールが可能であり、スクロールすると背景の要素を操作できてしまう。

### 確認手順：

- [ ] userもしくはadminでログインする
- [ ] spサイズにして適当なページでハンバーガーメニューをクリックしスライドメニューを表示する
- [ ] 縦スクロールが可能であり、背景要素が長い場合スクロールすることで背景要素を操作できてしまうのが確認できる。

### やったこと

- [ ] headerコンポーネントでuseEffectを用いて、hamburgerToggle stateの状態によって、htmlタグ,bodyタグのoverflowプロパティーをそれぞれhiddenとautoで切り替えるように記述

レビューお願いします。
