### PR TITLE
modify:#130:ログイン画面などコンテンツの中身が少ない状態の時のheightのあまりが生じることへの対処

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,7 +9,9 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <ContextProvidor>
         <Header />
-        <Component {...pageProps} />
+        <div className="min-h-[calc(100vh-160px-64px-80px)] md:min-h-[calc(100vh-220px-64px-80px)]" >
+          <Component {...pageProps} />
+        </div>
         <Footer className='mt-[80px]' />
       </ContextProvidor>
     </>


### PR DESCRIPTION
### issue
#130 

### 背景：
ログインページ、会員登録ページやapiから情報と撮ってきている最中に、mainコンテンツの中身が少ない時にページの高さが余って表示されてしまっている

### 確認手順：

- [ ] ログインページに遷移する
- [ ] ページの高さの下部が余り、余白として表示されてしまっているのが確認できる
- [ ] 会員登録ページも同様に確認できる
- [ ] ログイン後レビュー一覧ページなど適当な一覧ページに遷移してみる
- [ ] コンテンツのデータが取れてきていない間はページの下部が良学として表示されてしまっているのが確認できる。

### やったこと：

- [ ] _app.tsxで表示しているメインとなるコンテンツをdivで囲んで、そのdivにheader,footerの高さを考慮して計算したmin-heightを設定して、デフォルトのメインコンテンツの取る高さを設定した

### 備考：
このプルリクエスト時点でfooterにtailwind mt-[80px]を指定しているのでその値も考慮してmin-heightの値を計算している。なので各値が変更された時に、この計算の式を調整する必要が出てくるかもしれない

レビューお値がいします