### PR TITLE
clear: gut及びracket画像トリミング機能をカスタムフックとコンポーネントに切り出した

### DIFF
--- a/src/components/ImageCropArea.tsx
+++ b/src/components/ImageCropArea.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import Cropper, { Area, Point } from "react-easy-crop";
+import InputRange from "./inputRange";
+
+type Props = {
+  imageFileUrl: string,
+  crop: Point,
+  rotation: number,
+  zoom: number,
+  aspect: number,
+  setCrop: React.Dispatch<React.SetStateAction<Point>>,
+  setRotation:React.Dispatch<React.SetStateAction<number>>,
+  setZoom: React.Dispatch<React.SetStateAction<number>>,
+  onCropComplete: (croppedArea: Area, croppedAreaPixels: Area) => void,
+  showCroppedImage: (imageFileUrl: string) => Promise<void>,
+  zoomMin: number,
+  zoomMax: number,
+  zoomStep: number,
+  rotationMin: number,
+  rotationMax: number,
+  rotationStep: number,
+  clopperClassName?: string,
+  // inputZoomClassName?: string,
+  // inputRotationClassName?: string,
+}
+
+const ImageCropArea: React.FC<Props> = ({
+  imageFileUrl,
+  crop,
+  rotation,
+  zoom,
+  aspect,
+  setCrop,
+  setRotation,
+  setZoom,
+  onCropComplete,
+  showCroppedImage,
+  zoomMin,
+  zoomMax,
+  zoomStep,
+  rotationMin,
+  rotationMax,
+  rotationStep,
+  clopperClassName = 'h-[300px]  mb-8',
+  // inputZoomClassName = 'h-[16px] w-[100%] max-w-[220px] md:h-[18px]',
+  // inputRotationClassName = 'h-[16px] w-[100%] max-w-[220px] md:h-[18px]',
+}) => {
+  return (
+    <>
+      <div className={`!relative ${clopperClassName}`}>
+        <Cropper
+          image={imageFileUrl}
+          crop={crop}
+          rotation={rotation}
+          zoom={zoom}
+          aspect={aspect}
+          onCropChange={setCrop}
+          onRotationChange={setRotation}
+          onCropComplete={onCropComplete}
+          onZoomChange={setZoom}
+        />
+      </div>
+
+      <div className="flex justify-start w-[100%] mx-auto mb-8">
+        <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]">ズーム：</span>
+        <InputRange
+          min={zoomMin}
+          max={zoomMax}
+          step={zoomStep}
+          value={zoom}
+          chengeHandler={(e) => setZoom(Number(e.target.value))}
+        />
+      </div>
+
+      <div className="flex justify-center mt-6 mb-[40px]">
+
+        <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]" >回転：</span>
+        <InputRange
+          min={rotationMin}
+          max={rotationMax}
+          step={rotationStep}
+          value={rotation}
+          chengeHandler={(e) =>  setRotation(Number(e.target.value))}
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <p onClick={() => showCroppedImage(imageFileUrl)} className="inline-block border  hover:cursor-pointer hover:opacity-60 font-semibold text-white text-[14px] w-[192px] h-8 rounded  bg-sub-green text-center leading-[32px] md:text-[16px]">トリミングを完了</p>
+      </div>
+    </>
+  );
+}
+
+export default ImageCropArea;

--- a/src/hooks/useImageCrop.ts
+++ b/src/hooks/useImageCrop.ts
@@ -1,0 +1,71 @@
+// 使用法：
+// 基本的にImageCropAreaコンポーネント一緒に使用する
+// 使用先にて、このカスタムフックの各exportしている値、メソッドと
+// 使用先でinput:fileより取得変換したimageFileUrlを使って利用する
+
+import getCroppedImg, { CropedImageInfo } from "@/modules/cropImage";
+import { useState } from "react";
+import { Area, Point } from "react-easy-crop";
+
+const useImageCrop = () => {
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [rotation, setRotation] = useState(0)
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>()
+  const [croppedImage, setCroppedImage] = useState<File>();
+  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
+
+  const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
+    setCroppedAreaPixels(croppedAreaPixels)
+  };
+
+  const showCroppedImage = async (imageFileUrl: string) => {
+    try {
+      const cropedImageInfo: CropedImageInfo = await getCroppedImg(
+        imageFileUrl,
+        croppedAreaPixels as Area,
+        rotation
+      ) as CropedImageInfo
+
+      const croppedImage = cropedImageInfo.file;
+
+      const croppedImageUrl = cropedImageInfo.url
+
+      setCroppedImage(croppedImage);
+
+      setCroppedImageUrl(croppedImageUrl);
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const onClose = () => {
+    setCroppedImage(undefined);
+  }
+
+  return {
+    crop,
+    setCrop,
+
+    rotation,
+    setRotation,
+
+    zoom,
+    setZoom,
+
+    croppedAreaPixels,
+    setCroppedAreaPixels,
+
+    croppedImage,
+    setCroppedImage,
+
+    croppedImageUrl,
+    setCroppedImageUrl,
+
+    onCropComplete,
+    showCroppedImage,
+    onClose
+  }
+}
+
+export {useImageCrop};

--- a/src/hooks/useImageFile.ts
+++ b/src/hooks/useImageFile.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+const useImageFile = () => {
+  const [imageFileUrl, setImageFileUrl] = useState<string>('');
+
+  const changeImageFileToLocationUrl = (files: FileList | null) => {
+    if (files && files[0]) {
+      const reader = new FileReader();
+
+      reader.addEventListener('load', () => {
+        if (reader.result) {
+          setImageFileUrl(reader.result.toString() || '');
+        }
+      })
+      reader.readAsDataURL(files[0]);
+    }
+  }
+
+  return {
+    imageFileUrl,
+    setImageFileUrl,
+    changeImageFileToLocationUrl,
+  }
+}
+
+export { useImageFile }

--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -2,8 +2,6 @@ import type { NextPage } from "next";
 
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
-import Cropper, { type Point, Area } from "react-easy-crop";
-import getCroppedImg, { CropedImageInfo } from "@/modules/cropImage";
 
 import { useContext, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
@@ -13,6 +11,10 @@ import AuthCheck from "@/components/AuthCheck";
 import PrimaryHeading from "@/components/PrimaryHeading";
 import { type Maker } from "../users/[id]/profile";
 import FlashMessage from "@/components/FlashMessage";
+import ImageCropArea from "@/components/ImageCropArea";
+
+import { useImageCrop } from "@/hooks/useImageCrop";
+import { useImageFile } from "@/hooks/useImageFile";
 
 const GutImageRegister: NextPage = () => {
   const router = useRouter();
@@ -20,8 +22,6 @@ const GutImageRegister: NextPage = () => {
   const { isAuth, user, isAuthAdmin } = useContext(AuthContext);
 
   const [title, setTitle] = useState<string>('');
-
-  const [imageFileUrl, setImageFileUrl] = useState<string>('');
 
   const [makers, setMakers] = useState<Maker[]>();
 
@@ -33,6 +33,30 @@ const GutImageRegister: NextPage = () => {
   // flassメッセージの表示関連stateとuseEffect
   const [showingFlashMessage, setShowingFlashMessage] = useState<boolean>(false);
   const [showingFlashMessageStyle, setShowingFlashMessageStyle] = useState<string>('bottom-[-100%]')
+
+  // useImageCropカスタムフックから取得
+  const {
+    crop,
+    setCrop,
+    rotation,
+    setRotation,
+    zoom,
+    setZoom,
+    croppedAreaPixels,
+    setCroppedAreaPixels,
+    croppedImage,
+    setCroppedImage,
+    croppedImageUrl,
+    setCroppedImageUrl,
+    onCropComplete,
+    showCroppedImage,
+  } = useImageCrop();
+
+  const {
+    imageFileUrl,
+    setImageFileUrl,
+    changeImageFileToLocationUrl,
+  } = useImageFile();
 
   // 下記の2つのuseEffectによりflashメッセージを表示切り替え
   // 依存配列のstateを同じuseEffect内で書き換えるこのができないため2つのuseEffectを使用して実装
@@ -59,16 +83,7 @@ const GutImageRegister: NextPage = () => {
 
   const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
-    if (files && files[0]) {
-      const reader = new FileReader();
-
-      reader.addEventListener('load', () => {
-        if (reader.result) {
-          setImageFileUrl(reader.result.toString() || '');
-        }
-      })
-      reader.readAsDataURL(files[0]);
-    }
+    changeImageFileToLocationUrl(files);
   }
 
   const onChangeSelectMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -91,40 +106,6 @@ const GutImageRegister: NextPage = () => {
     getMakerList();
   }, [])
 
-  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
-  const [rotation, setRotation] = useState(0)
-  const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>()
-  const [croppedImage, setCroppedImage] = useState<File>();
-  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
-
-  const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
-    setCroppedAreaPixels(croppedAreaPixels)
-  };
-
-  const showCroppedImage = async () => {
-    try {
-      const cropedImageInfo: CropedImageInfo = await getCroppedImg(
-        imageFileUrl,
-        croppedAreaPixels as Area,
-        rotation
-      ) as CropedImageInfo
-
-      const croppedImage = cropedImageInfo.file;
-
-      const croppedImageUrl = cropedImageInfo.url
-
-      setCroppedImage(croppedImage);
-
-      setCroppedImageUrl(croppedImageUrl);
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  const onClose = () => {
-    setCroppedImage(undefined);
-  }
 
   type Errors = {
     title: string[],
@@ -148,6 +129,7 @@ const GutImageRegister: NextPage = () => {
     setCroppedAreaPixels(undefined)
     setCroppedImage(undefined)
     setCroppedImageUrl(undefined)
+    setErrors({ title: [], file: [], maker_id: [] })
   }
 
   const csrf = async () => await axios.get('/sanctum/csrf-cookie');
@@ -245,56 +227,24 @@ const GutImageRegister: NextPage = () => {
 
                         {imageFileUrl && (
                           <>
-                            <div className="h-[300px] relative mb-8">
-                              <Cropper
-                                image={imageFileUrl}
-                                crop={crop}
-                                rotation={rotation}
-                                zoom={zoom}
-                                aspect={3 / 4}
-                                onCropChange={setCrop}
-                                onRotationChange={setRotation}
-                                onCropComplete={onCropComplete}
-                                onZoomChange={setZoom}
-                              />
-                            </div>
-
-                            <div className="flex justify-start w-[100%] max-w-[288px] mx-auto mb-8">
-                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]">ズーム：</span>
-                              <input
-                                type="range"
-                                value={zoom}
-                                min={1}
-                                max={3}
-                                step={0.1}
-                                aria-labelledby="Zoom"
-                                onChange={(e) => {
-                                  setZoom(Number(e.target.value))
-                                }}
-                                className="inline-block h-[16px] w-[100%] max-w-[220px] md:h-[18px]"
-                              />
-                            </div>
-
-                            <div className="flex justify-center mt-6 mb-[40px]">
-
-                              <span className="inline-block h-[16px] text-[14px] text-center w-[100%] max-w-[68px] md:text-[16px] md:h-[18px] leading-[18px]" >回転：</span>
-                              <input
-                                type="range"
-                                value={rotation}
-                                min={0}
-                                max={360}
-                                step={0.5}
-                                aria-labelledby="Rotation"
-                                onChange={(e) => {
-                                  setRotation(Number(e.target.value))
-                                }}
-                                className="inline-block h-[16px] w-[100%] max-w-[220px] md:h-[18px]"
-                              />
-                            </div>
-
-                            <div className="flex justify-end">
-                              <p onClick={showCroppedImage} className="inline-block border  hover:cursor-pointer hover:opacity-60 font-semibold text-white text-[14px] w-[192px] h-8 rounded  bg-sub-green text-center leading-[32px] md:text-[16px]">トリミングを完了</p>
-                            </div>
+                            <ImageCropArea
+                              imageFileUrl={imageFileUrl}
+                              crop={crop}
+                              rotation={rotation}
+                              zoom={zoom}
+                              aspect={3 / 4}
+                              setCrop={setCrop}
+                              setRotation={setRotation}
+                              setZoom={setZoom}
+                              onCropComplete={onCropComplete}
+                              showCroppedImage={showCroppedImage}
+                              zoomMin={1}
+                              zoomMax={3}
+                              zoomStep={0.05}
+                              rotationMin={0}
+                              rotationMax={360}
+                              rotationStep={0.5}
+                            />
                           </>
                         )}
                       </div>


### PR DESCRIPTION
### issue:
 #134 

### 背景：
gut及びracketイメージ登録画面で実装している画像トリミング機能がそれぞれの場所で定義しており、他の場所で画像トリミング機能を使いたくなった時に再度処理を記述しなければいけないので、処理を切り出したい。

### 確認手順；

- [ ] gut_image登録処理のコードを確認する
- [ ] racket_image登録処理のコードを確認する
- [ ] それぞれの場所で画像トリミング機能を実装してしまっているのが確認できる。

### やったこと

- [ ] gut画像トリミング処理について、ImageCropAreaコンポーネントに要素を切り出し
- [ ] 状態管理の部分をuseImageCrop,useImageFileカスタムフックに切り出し
- [ ] ImageCropAreaコンポーネントとuseImageCrop,useImageFileカスタムフックを使ってgut画像トリミング処理を置き換えた
- [ ] racket画像トリミング機能について、上記で切り出したカスタムフックとコンポーネントで同様にしてトリミング処理を置き換えた

### 備考：
コンポーネント及びカスタムフックに切り出す際に、合わせて画像のファイルをinputたぐで扱う時はその画像ファイルのローカルの場所を示すurlに変換する機能をuseImageFileカスタムフックで定義しているので、今後画像ファイルのローカルの場所を示すurlに変換する処理を実装するときは利用してください。

レビューお願いします