### PR TITLE
modify: racket及びgut検索モーダル使用部分をコンポーネントで置き換えた

### DIFF
--- a/src/components/GutSearchModal.tsx
+++ b/src/components/GutSearchModal.tsx
@@ -28,6 +28,15 @@ type GutSearchModalProps = {
   makers?: Maker[],
   searchedGuts?: Gut[],
   zIndexClassName?: string,
+
+  gutsPaginator?: Paginator<Gut> | undefined,
+  setGutsPaginator?: React.Dispatch<React.SetStateAction<Paginator<Gut> | undefined>>,
+
+  inputSearchWord: string,
+  setInputSearchWord: React.Dispatch<React.SetStateAction<string>>,
+
+  inputSearchMaker: number | undefined,
+  setInputSearchMaker: React.Dispatch<React.SetStateAction<number | undefined>>,
 }
 
 const GutSearchModal: React.FC<GutSearchModalProps> = ({
@@ -40,12 +49,16 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
   searchedGuts,
   setSearchedGuts,
   zIndexClassName,
-}) => {
-  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
 
-  // 検索input関連state
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  setGutsPaginator,
+
+  inputSearchWord,
+  setInputSearchWord,
+  inputSearchMaker,
+  setInputSearchMaker,
+}) => {
+  // モーダル内ページネーション用
+  const [gutsModalPaginator, setGutsModalPaginator] = useState<Paginator<Gut>>();
 
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
@@ -60,7 +73,7 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
 
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
+      setInputSearchMaker(undefined);
       return
     };
 
@@ -70,7 +83,11 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
   //ページネーションを考慮した検索後gut一覧データの取得関数
   const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
     await axios.get(url).then((res) => {
-      setGutsPaginator(res.data);
+      setGutsModalPaginator(res.data);
+
+      if (setGutsPaginator) {
+        setGutsPaginator(res.data);
+      }
 
       setSearchedGuts(res.data.data);
     })
@@ -96,7 +113,10 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
   const closeModal = () => {
     setModalVisibility(false);
     setModalVisibilityClassName('opacity-0 scale-0')
-    closeModalHandler();
+
+    if(closeModalHandler) {
+      closeModalHandler();
+    }
   }
 
   const selectGut = (gut: Gut) => {
@@ -117,13 +137,25 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
           <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
             <div className="mb-6 md:mb-0 md:mr-[16px]">
               <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
-              <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+              <input
+                type="text"
+                name="several_words"
+                onChange={(e) => setInputSearchWord(e.target.value)}
+                value={inputSearchWord ? inputSearchWord : ''}
+                className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
+              />
             </div>
 
             <div className="mb-8 md:mb-0 md:mr-[24px]">
               <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
 
-              <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+              <select
+                name="maker" 
+                id="maker"
+                onChange={(e) => { onChangeInputSearchMaker(e) }}
+                value={inputSearchMaker ? inputSearchMaker : '未選択'}
+                className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
+              >
                 <option value="未選択" selected>未選択</option>
                 {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
               </select>
@@ -163,7 +195,7 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
                 </div>
 
                 <Pagination
-                  paginator={gutsPaginator}
+                  paginator={gutsModalPaginator}
                   paginate={getSearchedGutsList}
                   className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
                 />

--- a/src/components/RacketSearchModal.tsx
+++ b/src/components/RacketSearchModal.tsx
@@ -27,6 +27,15 @@ type RacketSearchModalProps = {
   makers?: Maker[],
   searchedRackets?: Racket[],
   zIndexClassName?: string,
+
+  racketsPaginator?: Paginator<Racket> | undefined,
+  setRacketsPaginator?: React.Dispatch<React.SetStateAction<Paginator<Racket> | undefined>>,
+
+  inputSearchWord: string,
+  setInputSearchWord: React.Dispatch<React.SetStateAction<string>>,
+
+  inputSearchMaker: number | undefined,
+  setInputSearchMaker: React.Dispatch<React.SetStateAction<number | undefined>>,
 }
 
 const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
@@ -39,12 +48,17 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
   searchedRackets,
   setSearchedRackets,
   zIndexClassName,
-}) => {
-  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
 
-  // 検索input関連state
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  setRacketsPaginator,
+
+  inputSearchWord,
+  setInputSearchWord,
+  inputSearchMaker,
+  setInputSearchMaker,
+}) => {
+  // モーダル内のページネーション用
+  const [racketsModalPaginator, setRacketsModalPaginator] = useState<Paginator<Racket>>();
+
 
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
@@ -60,7 +74,7 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
 
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
+      setInputSearchMaker(undefined);
       return
     };
 
@@ -70,7 +84,11 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
   //ページネーションを考慮した検索後racket一覧データの取得関数
   const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
     await axios.get(url).then((res) => {
-      setRacketsPaginator(res.data);
+      setRacketsModalPaginator(res.data)
+
+      if(setRacketsPaginator) {
+        setRacketsPaginator(res.data);
+      }
 
       setSearchedRackets(res.data.data);
     })
@@ -96,7 +114,10 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
   const closeModal = () => {
     setModalVisibility(false);
     setModalVisibilityClassName('opacity-0 scale-0')
-    closeModalHandler();
+
+    if(closeModalHandler) {
+      closeModalHandler();
+    }
   }
 
   const selectRacket = (racket: Racket) => {
@@ -117,13 +138,25 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
           <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
             <div className="mb-6 md:mb-0 md:mr-[16px]">
               <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
-              <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
+              <input
+                type="text"
+                name="several_words"
+                onChange={(e) => setInputSearchWord(e.target.value)}
+                value={inputSearchWord ? inputSearchWord : ''}
+                className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
+              />
             </div>
 
             <div className="mb-8 md:mb-0 md:mr-[24px]">
               <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
 
-              <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
+              <select
+                name="maker"
+                id="maker"
+                onChange={(e) => { onChangeInputSearchMaker(e) }}
+                value={inputSearchMaker ? inputSearchMaker : '未選択'}
+                className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
+              >
                 <option value="未選択" selected>未選択</option>
                 {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
               </select>
@@ -163,7 +196,7 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
                 </div>
 
                 <Pagination
-                  paginator={racketsPaginator}
+                  paginator={racketsModalPaginator}
                   paginate={getSearchedRacketsList}
                   className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
                 />

--- a/src/context/ReviewContext.tsx
+++ b/src/context/ReviewContext.tsx
@@ -69,6 +69,18 @@ type ContextVals = {
 
   physique: Physique | undefined,
   setPhysique: React.Dispatch<React.SetStateAction<Physique | undefined>>,
+
+  inputGutSearchWord: string,
+  setInputGutSearchWord: React.Dispatch<React.SetStateAction<string>>,
+
+  inputGutSearchMaker?: number,
+  setInputGutSearchMaker: React.Dispatch<React.SetStateAction<number | undefined>>,
+
+  inputRacketSearchWord: string,
+  setInputRacketSearchWord: React.Dispatch<React.SetStateAction<string>>,
+
+  inputRacketSearchMaker?: number,
+  setInputRacketSearchMaker: React.Dispatch<React.SetStateAction<number | undefined>>,
 }
 
 const initialContextVals = {
@@ -135,6 +147,18 @@ const initialContextVals = {
 
   physique: undefined,
   setPhysique: () => { },
+
+  inputGutSearchWord: '',
+  setInputGutSearchWord: () => { },
+
+  inputGutSearchMaker: undefined,
+  setInputGutSearchMaker: () => { },
+
+  inputRacketSearchWord: '',
+  setInputRacketSearchWord: () => { },
+
+  inputRacketSearchMaker: undefined,
+  setInputRacketSearchMaker: () => { },
 }
 
 const ReviewContext = createContext<ContextVals>(initialContextVals);
@@ -176,6 +200,12 @@ const ReviewContextProvider: React.FC<Props> = ({ children }) => {
   const [height, setHeight] = useState<Height | undefined>();
   const [physique, setPhysique] = useState<Physique | undefined>();
 
+  // レビュー検索モーダル内、ラケット、ガット検索モーダルinput値
+  const [inputGutSearchWord, setInputGutSearchWord] = useState<string>('');
+  const [inputGutSearchMaker, setInputGutSearchMaker] = useState<number>();
+  const [inputRacketSearchWord, setInputRacketSearchWord] = useState<string>('');
+  const [inputRacketSearchMaker, setInputRacketSearchMaker] = useState<number>();
+
   const contextVals = {
     reviewsPaginator,
     setReviewsPaginator,
@@ -209,6 +239,18 @@ const ReviewContextProvider: React.FC<Props> = ({ children }) => {
 
     racket,
     setRacket,
+
+    inputGutSearchWord,
+    setInputGutSearchWord,
+
+    inputGutSearchMaker,
+    setInputGutSearchMaker,
+
+    inputRacketSearchWord,
+    setInputRacketSearchWord,
+
+    inputRacketSearchMaker,
+    setInputRacketSearchMaker,
 
     experiencePeriod,
     setExperiencePeriod,

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -15,6 +15,7 @@ import { IoClose } from "react-icons/io5";
 import Pagination, { type Paginator } from "@/components/Pagination";
 import { GutContext } from "@/context/GutContext";
 import { usePathHistory } from "@/context/HistoryContext";
+import GutSearchModal from "@/components/GutSearchModal";
 
 const GutList = () => {
   const router = useRouter();
@@ -34,14 +35,12 @@ const GutList = () => {
     setInputSearchMaker,
   } = useContext(GutContext);
 
-  console.log('inputSearchMaker', inputSearchMaker)
-
   const [makers, setMakers] = useState<Maker[]>();
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
   //モーダルの開閉に関するstate
-  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+  const [gutSearchModalVisibility, setGutSearchModalVisibility] = useState<boolean>(false);
 
   //ページネーションを考慮したgut一覧データの取得関数
   const getGutsList = async (url: string = 'api/guts') => {
@@ -83,16 +82,12 @@ const GutList = () => {
     setInputSearchMaker(Number(e.target.value));
   }
 
-  //モーダルの開閉
-  const closeModal = () => {
-    setModalVisibilityClassName('opacity-0 scale-0')
-  }
-
+  // モーダルの開閉
   const openModal = () => {
-    setModalVisibilityClassName('opacity-100 scale-100')
+    setGutSearchModalVisibility(true)
   }
 
-  //gut検索
+  //pcレイアウト時のgut検索
   const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -102,8 +97,6 @@ const GutList = () => {
         maker: inputSearchMaker
       }
     }).then((res) => {
-      closeModal();
-
       setGutsPaginator(res.data)
 
       setGuts(res.data.data);
@@ -193,45 +186,20 @@ const GutList = () => {
             </div>
 
             {/* 検索モーダル */}
-            <div className={`bg-gray-300 w-screen min-h-[100%] absolute top-[64px] left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto md:hidden`}>
-              <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                  <IoClose size={48} />
-                </div>
-
-                <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
-                  <div className="mb-6 md:mb-0 md:mr-[16px]">
-                    <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング検索ワード</label>
-                    <input
-                      type="text"
-                      name="name_ja"
-                      defaultValue={inputSearchWord}
-                      onChange={(e) => setInputSearchWord(e.target.value)}
-                      className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
-                    />
-                  </div>
-
-                  <div className="mb-8 md:mb-0 md:mr-[24px]">
-                    <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                    <select
-                      name="maker"
-                      id="maker"
-                      value={inputSearchMaker ? inputSearchMaker : '未選択'}
-                      onChange={(e) => { onChangeInputSearchMaker(e) }}
-                      className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
-                    >
-                      <option value="未選択" selected>未選択</option>
-                      {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                    </select>
-                  </div>
-
-                  <div className="flex justify-end md:justify-start">
-                    <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                  </div>
-                </form>
-              </div>
-            </div>
+            <GutSearchModal
+              modalVisibility={gutSearchModalVisibility}
+              setModalVisibility={setGutSearchModalVisibility}
+              makers={makers}
+              showingResult={false}
+              searchedGuts={guts}
+              setSearchedGuts={setGuts}
+              zIndexClassName={'z-50'}
+              setGutsPaginator={setGutsPaginator}
+              inputSearchWord={inputSearchWord}
+              setInputSearchWord={setInputSearchWord}
+              inputSearchMaker={inputSearchMaker}
+              setInputSearchMaker={setInputSearchMaker}
+            />
 
             {/* ページネーション */}
             <Pagination

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -17,6 +17,8 @@ import TextUnderBar from "@/components/TextUnderBar";
 import { IoClose } from "react-icons/io5";
 import Pagination, { Paginator } from "@/components/Pagination";
 import { getToday } from "@/modules/getToday";
+import GutSearchModal from "@/components/GutSearchModal";
+import RacketSearchModal from "@/components/RacketSearchModal";
 
 const MyEquipmentEdit: NextPage = () => {
 
@@ -59,27 +61,19 @@ const MyEquipmentEdit: NextPage = () => {
   const [comment, setComment] = useState<string>('');
 
   //モーダルの開閉に関するstate
-  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
-
-  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+  const [gutSearchModalVisibility, setGutSearchModalVisibility] = useState<boolean>(false);
 
   const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
 
-  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
-
   //検索関連のstate
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  const [inputGutSearchWord, setInputGutSearchWord] = useState<string>('');
+  const [inputGutSearchMaker, setInputGutSearchMaker] = useState<number>();
+  const [inputRacketSearchWord, setInputRacketSearchWord] = useState<string>('');
+  const [inputRacketSearchMaker, setInputRacketSearchMaker] = useState<number>();
 
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
 
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
-
-  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
-
-  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
-
 
   useEffect(() => {
     const getMakerList = async () => {
@@ -112,12 +106,10 @@ const MyEquipmentEdit: NextPage = () => {
 
   // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
-    if (modalVisibility) {
-      setModalVisibilityClassName('opacity-100 scale-100')
+    if (gutSearchModalVisibility) {
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -126,16 +118,14 @@ const MyEquipmentEdit: NextPage = () => {
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
-  }, [modalVisibility])
+  }, [gutSearchModalVisibility])
 
   // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
     if (racketSearchModalVisibility) {
-      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -154,11 +144,11 @@ const MyEquipmentEdit: NextPage = () => {
 
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
+      setInputGutSearchMaker(undefined);
       return
     };
 
-    setInputSearchMaker(Number(e.target.value));
+    setInputGutSearchMaker(Number(e.target.value));
   }
 
   const onChangeInputNewGutDate = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -179,84 +169,31 @@ const MyEquipmentEdit: NextPage = () => {
 
   //モーダルの開閉
   const closeModal = () => {
-    setModalVisibility(false);
-    setModalVisibilityClassName('opacity-0 scale-0')
+    setGutSearchModalVisibility(false);
     setWitchSelectingGut('');
-  }
-
-  const openModal = () => {
-    setModalVisibilityClassName('opacity-100 scale-100')
   }
 
   //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
   const openMainGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('main');
   }
 
   const openCrossGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('cross');
   }
 
   //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
   const openRacketSearchModal = () => {
     setRacketSearchModalVisibility(true);
-    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
     setRacketSearchModalVisibility(false)
-    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
-
-  //ページネーションを考慮した検索後gut一覧データの取得関数
-  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setGutsPaginator(res.data);
-
-      setSearchedGuts(res.data.data);
-    })
-  }
-
-  //gut検索
-  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      getSearchedGutsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  //ページネーションを考慮した検索後racket一覧データの取得関数
-  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setRacketsPaginator(res.data);
-
-      setSearchedRackets(res.data.data);
-    })
-  }
-
-  //racket検索
-  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-
-    try {
-      getSearchedRacketsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
 
   const selectGut = (gut: Gut) => {
     if (witchSelectingGut === 'main') {
@@ -267,6 +204,7 @@ const MyEquipmentEdit: NextPage = () => {
 
     closeModal();
   }
+
   const selectRacket = (racket: Racket) => {
     setRacket(racket)
     closeRacketSearchModal();
@@ -649,127 +587,37 @@ const MyEquipmentEdit: NextPage = () => {
                 </form>
 
                 {/* gut検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ガット */}
-                        {searchedGuts && searchedGuts.map(gut => (
-                          <>
-                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {gut.gut_image.file_path
-                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-
-                      </div>
-                      <Pagination
-                        paginator={gutsPaginator}
-                        paginate={getSearchedGutsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-
-                  </div>
-                </div>
+                <GutSearchModal
+                  modalVisibility={gutSearchModalVisibility}
+                  setModalVisibility={setGutSearchModalVisibility}
+                  makers={makers}
+                  closeModalHandler={closeModal}
+                  selectGutHandler={selectGut}
+                  showingResult={true}
+                  searchedGuts={searchedGuts}
+                  setSearchedGuts={setSearchedGuts}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputGutSearchWord}
+                  setInputSearchWord={setInputGutSearchWord}
+                  inputSearchMaker={inputGutSearchMaker}
+                  setInputSearchMaker={setInputGutSearchMaker}
+                />
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ラケット */}
-                        {searchedRackets && searchedRackets.map(racket => (
-                          <>
-                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {racket.racket_image.file_path
-                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-                      </div>
-
-                      <Pagination
-                        paginator={racketsPaginator}
-                        paginate={getSearchedRacketsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-                  </div>
-                </div>
+                <RacketSearchModal
+                  modalVisibility={racketSearchModalVisibility}
+                  setModalVisibility={setRacketSearchModalVisibility}
+                  makers={makers}
+                  selectRacketHandler={selectRacket}
+                  showingResult={true}
+                  searchedRackets={searchedRackets}
+                  setSearchedRackets={setSearchedRackets}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputRacketSearchWord}
+                  setInputSearchWord={setInputRacketSearchWord}
+                  inputSearchMaker={inputRacketSearchMaker}
+                  setInputSearchMaker={setInputRacketSearchMaker}
+                />
               </div>
             </div>
           </>

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -16,6 +16,8 @@ import TextUnderBar from "@/components/TextUnderBar";
 import { IoClose } from "react-icons/io5";
 import Pagination, { Paginator } from "@/components/Pagination";
 import { getToday } from "@/modules/getToday";
+import GutSearchModal from "@/components/GutSearchModal";
+import RacketSearchModal from "@/components/RacketSearchModal";
 
 const MyEquipmentRegister: NextPage = () => {
   const router = useRouter();
@@ -56,7 +58,7 @@ const MyEquipmentRegister: NextPage = () => {
   const [comment, setComment] = useState<string>('');
 
   //モーダルの開閉に関するstate
-  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
+  const [gutSearchModalVisibility, setGutSearchModalVisibility] = useState<boolean>(false);
 
   const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
@@ -65,17 +67,14 @@ const MyEquipmentRegister: NextPage = () => {
   const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   //検索関連のstate
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  const [inputGutSearchWord, setInputGutSearchWord] = useState<string>('');
+  const [inputGutSearchMaker, setInputGutSearchMaker] = useState<number>();
+  const [inputRacketSearchWord, setInputRacketSearchWord] = useState<string>('');
+  const [inputRacketSearchMaker, setInputRacketSearchMaker] = useState<number>();
 
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
 
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
-
-  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
-
-  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
 
   useEffect(() => {
     const getMakerList = async () => {
@@ -96,12 +95,10 @@ const MyEquipmentRegister: NextPage = () => {
 
   // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
-    if (modalVisibility) {
-      setModalVisibilityClassName('opacity-100 scale-100')
+    if (gutSearchModalVisibility) {
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -110,16 +107,14 @@ const MyEquipmentRegister: NextPage = () => {
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
-  }, [modalVisibility])
+  }, [gutSearchModalVisibility])
 
   // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
     if (racketSearchModalVisibility) {
-      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -134,15 +129,6 @@ const MyEquipmentRegister: NextPage = () => {
   const onChangeInputStringingWay = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setStringingWay(e.target.value);
     setCrossGut(undefined);
-  }
-
-  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
-      return
-    };
-
-    setInputSearchMaker(Number(e.target.value));
   }
 
   const onChangeInputNewGutDate = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -163,25 +149,18 @@ const MyEquipmentRegister: NextPage = () => {
 
   //モーダルの開閉
   const closeModal = () => {
-    setModalVisibility(false);
-    setModalVisibilityClassName('opacity-0 scale-0')
+    setGutSearchModalVisibility(false);
     setWitchSelectingGut('');
-  }
-
-  const openModal = () => {
-    setModalVisibilityClassName('opacity-100 scale-100')
   }
 
   //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
   const openMainGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('main');
   }
 
   const openCrossGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('cross');
   }
 
@@ -198,50 +177,6 @@ const MyEquipmentRegister: NextPage = () => {
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
 
-  //ページネーションを考慮した検索後racket一覧データの取得関数
-  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setGutsPaginator(res.data);
-
-      setSearchedGuts(res.data.data);
-    })
-  }
-
-  //gut検索
-  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      getSearchedGutsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  //ページネーションを考慮した検索後racket一覧データの取得関数
-  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setRacketsPaginator(res.data);
-
-      setSearchedRackets(res.data.data);
-    })
-  }
-
-  //racket検索
-  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-
-    try {
-      getSearchedRacketsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
   const selectGut = (gut: Gut) => {
     if (witchSelectingGut === 'main') {
       setMainGut(gut);
@@ -251,6 +186,7 @@ const MyEquipmentRegister: NextPage = () => {
 
     closeModal();
   }
+  
   const selectRacket = (racket: Racket) => {
     setRacket(racket)
     closeRacketSearchModal();
@@ -631,128 +567,37 @@ const MyEquipmentRegister: NextPage = () => {
                 </form>
 
                 {/* gut検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
-                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ガット */}
-                        {searchedGuts && searchedGuts.map(gut => (
-                          <>
-                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {gut.gut_image.file_path
-                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-
-                      </div>
-
-                      <Pagination
-                        paginator={gutsPaginator}
-                        paginate={getSearchedGutsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-
-                  </div>
-                </div>
+                <GutSearchModal
+                  modalVisibility={gutSearchModalVisibility}
+                  setModalVisibility={setGutSearchModalVisibility}
+                  makers={makers}
+                  closeModalHandler={closeModal}
+                  selectGutHandler={selectGut}
+                  showingResult={true}
+                  searchedGuts={searchedGuts}
+                  setSearchedGuts={setSearchedGuts}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputGutSearchWord}
+                  setInputSearchWord={setInputGutSearchWord}
+                  inputSearchMaker={inputGutSearchMaker}
+                  setInputSearchMaker={setInputGutSearchMaker}
+                />
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ラケット */}
-                        {searchedRackets && searchedRackets.map(racket => (
-                          <>
-                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {racket.racket_image.file_path
-                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-                      </div>
-
-                      <Pagination
-                        paginator={racketsPaginator}
-                        paginate={getSearchedRacketsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-                  </div>
-                </div>
+                <RacketSearchModal
+                  modalVisibility={racketSearchModalVisibility}
+                  setModalVisibility={setRacketSearchModalVisibility}
+                  makers={makers}
+                  selectRacketHandler={selectRacket}
+                  showingResult={true}
+                  searchedRackets={searchedRackets}
+                  setSearchedRackets={setSearchedRackets}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputRacketSearchWord}
+                  setInputSearchWord={setInputRacketSearchWord}
+                  inputSearchMaker={inputRacketSearchMaker}
+                  setInputSearchMaker={setInputRacketSearchMaker}
+                />
               </div>
             </div>
           </>

--- a/src/pages/rackets/index.tsx
+++ b/src/pages/rackets/index.tsx
@@ -5,6 +5,8 @@ import { firstLetterToUpperCase } from "@/modules/firstLetterToUpperCase";
 
 import { useContext, useEffect, useState } from "react";
 import { AuthContext } from "@/context/AuthContext";
+import { RacketContext } from "@/context/RacketContext";
+import { usePathHistory } from "@/context/HistoryContext";
 import { useRouter } from "next/router";
 
 import Link from "next/link";
@@ -13,8 +15,7 @@ import PrimaryHeading from "@/components/PrimaryHeading";
 import TextUnderBar from "@/components/TextUnderBar";
 import { IoClose } from "react-icons/io5";
 import Pagination, { type Paginator } from "@/components/Pagination";
-import { RacketContext } from "@/context/RacketContext";
-import { usePathHistory } from "@/context/HistoryContext";
+import RacketSearchModal from "@/components/RacketSearchModal";
 
 
 const RacketList = () => {
@@ -38,7 +39,7 @@ const RacketList = () => {
   const [makers, setMakers] = useState<Maker[]>();
 
   //モーダルの開閉に関するstate
-  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+  const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/';
 
@@ -79,15 +80,11 @@ const RacketList = () => {
   }
 
   //モーダルの開閉
-  const closeModal = () => {
-    setModalVisibilityClassName('opacity-0 scale-0')
-  }
-
   const openModal = () => {
-    setModalVisibilityClassName('opacity-100 scale-100')
+    setRacketSearchModalVisibility(true);
   }
 
-  //racket検索
+  //pcレイアウト用racket検索
   const searchRackets = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -97,8 +94,6 @@ const RacketList = () => {
         maker: inputSearchMaker
       }
     }).then((res) => {
-      closeModal();
-
       setRacketsPaginator(res.data)
 
       setRackets(res.data.data);
@@ -203,61 +198,20 @@ const RacketList = () => {
               </div>
 
               {/* 検索モーダル */}
-              <div className={`bg-gray-300 w-screen min-h-[100%] absolute top-[64px] left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-auto md:hidden`}>
-                <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                  <div
-                    onClick={closeModal}
-                    className="self-end hover:cursor-pointer md:mr-[39px]"
-                  >
-                    <IoClose size={48} />
-                  </div>
-
-                  <form
-                    onSubmit={searchRackets}
-                    className="mb-[24px] md:flex md:mb-[40px]"
-                  >
-                    <div className="mb-6 md:mb-0 md:mr-[16px]">
-                      <label
-                        htmlFor="name_ja"
-                        className="block mb-1 text-[14px] md:text-[16px] md:mb-2"
-                      >ストリング検索ワード</label>
-
-                      <input
-                        type="text"
-                        name="name_ja"
-                        defaultValue={inputSearchWord}
-                        onChange={(e) => setInputSearchWord(e.target.value)}
-                        className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
-                      />
-                    </div>
-
-                    <div className="mb-8 md:mb-0 md:mr-[24px]">
-                      <label
-                        htmlFor="maker"
-                        className="block text-[14px] mb-1 md:text-[16px] md:mb-2"
-                      >メーカー</label>
-
-                      <select
-                        name="maker"
-                        id="maker"
-                        value={inputSearchMaker ? inputSearchMaker : '未選択'}
-                        onChange={(e) => { onChangeInputSearchMaker(e) }}
-                        className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
-                      >
-                        <option value="未選択">未選択</option>
-                        {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                      </select>
-                    </div>
-
-                    <div className="flex justify-end md:justify-start">
-                      <button
-                        type="submit"
-                        className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]"
-                      >検索する</button>
-                    </div>
-                  </form>
-                </div>
-              </div>
+              <RacketSearchModal
+                modalVisibility={racketSearchModalVisibility}
+                setModalVisibility={setRacketSearchModalVisibility}
+                makers={makers}
+                showingResult={false}
+                searchedRackets={rackets}
+                setSearchedRackets={setRackets}
+                zIndexClassName="z-50"
+                setRacketsPaginator={setRacketsPaginator}
+                inputSearchWord={inputSearchWord}
+                setInputSearchWord={setInputSearchWord}
+                inputSearchMaker={inputSearchMaker}
+                setInputSearchMaker={setInputSearchMaker}
+              />
 
               {/* ページネーション */}
               <Pagination

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -16,6 +16,8 @@ import TextUnderBar from "@/components/TextUnderBar";
 import { IoClose } from "react-icons/io5";
 import Pagination, { Paginator } from "@/components/Pagination";
 import EvaluationRangeItem from "@/components/EvaluationRangeItem";
+import GutSearchModal from "@/components/GutSearchModal";
+import RacketSearchModal from "@/components/RacketSearchModal";
 import { getToday } from "@/modules/getToday";
 
 type EditingGutReviewData = {
@@ -73,28 +75,19 @@ const GutReviewEdit: NextPage = () => {
   const [inputMainCrossTension, setInputCrossGutTension] = useState<number>(50);
 
   //モーダルの開閉に関するstate
-  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
-
-  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+  const [gutSearchModalVisibility, setGutSearchModalVisibility] = useState<boolean>(false);
 
   const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
 
-  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
-
-  const [myEquipmentSearchModalVisibility, setMyEquipmentModalVisibility] = useState<boolean>(false);
-
   //検索関連のstate
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  const [inputGutSearchWord, setInputGutSearchWord] = useState<string>('');
+  const [inputGutSearchMaker, setInputGutSearchMaker] = useState<number>();
+  const [inputRacketSearchWord, setInputRacketSearchWord] = useState<string>('');
+  const [inputRacketSearchMaker, setInputRacketSearchMaker] = useState<number>();
 
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
 
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
-
-  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
-
-  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
 
   // 評価に関するstate
   const [matchRate, setMatchRate] = useState<number>(3);
@@ -125,7 +118,7 @@ const GutReviewEdit: NextPage = () => {
     // 各データの初期値をセット
     const setInitialStates = async () => {
       const _review: Review = await getReview();
-      
+
       setReview(_review);
       setMyEquipment(_review.my_equipment);
       setStringingWay(_review.my_equipment.stringing_way)
@@ -149,12 +142,10 @@ const GutReviewEdit: NextPage = () => {
 
   // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
-    if (modalVisibility) {
-      setModalVisibilityClassName('opacity-100 scale-100')
+    if (gutSearchModalVisibility) {
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -163,16 +154,14 @@ const GutReviewEdit: NextPage = () => {
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
-  }, [modalVisibility])
+  }, [gutSearchModalVisibility])
 
   // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
     if (racketSearchModalVisibility) {
-      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -191,93 +180,40 @@ const GutReviewEdit: NextPage = () => {
 
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
+      setInputGutSearchMaker(undefined);
       return
     };
 
-    setInputSearchMaker(Number(e.target.value));
+    setInputGutSearchMaker(Number(e.target.value));
   }
 
   //モーダルの開閉
   const closeModal = () => {
-    setModalVisibility(false);
-    setModalVisibilityClassName('opacity-0 scale-0')
+    setGutSearchModalVisibility(false);
     setWitchSelectingGut('');
-  }
-
-  const openModal = () => {
-    setModalVisibilityClassName('opacity-100 scale-100')
   }
 
   //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
   const openMainGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('main');
   }
 
   const openCrossGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('cross');
   }
 
   //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
   const openRacketSearchModal = () => {
     setRacketSearchModalVisibility(true);
-    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
     setRacketSearchModalVisibility(false)
-    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
-
-  //ページネーションを考慮した検索後gut一覧データの取得関数
-  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setGutsPaginator(res.data);
-
-      setSearchedGuts(res.data.data);
-    })
-  }
-
-  //gut検索
-  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      getSearchedGutsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  //ページネーションを考慮した検索後racket一覧データの取得関数
-  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setRacketsPaginator(res.data);
-
-      setSearchedRackets(res.data.data);
-    })
-  }
-
-  //racket検索
-  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-
-    try {
-      getSearchedRacketsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
 
   const selectGut = (gut: Gut) => {
     if (witchSelectingGut === 'main') {
@@ -367,7 +303,7 @@ const GutReviewEdit: NextPage = () => {
   }
 
   const resetMyEquipmentState = () => {
-    if(myEquipment) {
+    if (myEquipment) {
       setStringingWay(myEquipment?.stringing_way)
       setMainGut(myEquipment.main_gut)
       setCrossGut(myEquipment.cross_gut)
@@ -382,7 +318,7 @@ const GutReviewEdit: NextPage = () => {
   }
 
   const resetEvaluationState = () => {
-    if(review) {
+    if (review) {
       setMatchRate(review.match_rate);
       setPysicalDurability(review.pysical_durability)
       setPerformanceDurability(review.performance_durability)
@@ -739,129 +675,37 @@ const GutReviewEdit: NextPage = () => {
                 </form>
 
                 {/* gut検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
-                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ガット */}
-                        {searchedGuts && searchedGuts.map(gut => (
-                          <>
-                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {gut.gut_image.file_path
-                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-
-                      </div>
-
-                      <Pagination
-                        paginator={gutsPaginator}
-                        paginate={getSearchedGutsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-
-                  </div>
-                </div>
+                <GutSearchModal
+                  modalVisibility={gutSearchModalVisibility}
+                  setModalVisibility={setGutSearchModalVisibility}
+                  makers={makers}
+                  closeModalHandler={closeModal}
+                  selectGutHandler={selectGut}
+                  showingResult={true}
+                  searchedGuts={searchedGuts}
+                  setSearchedGuts={setSearchedGuts}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputGutSearchWord}
+                  setInputSearchWord={setInputGutSearchWord}
+                  inputSearchMaker={inputGutSearchMaker}
+                  setInputSearchMaker={setInputGutSearchMaker}
+                />
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ラケット */}
-                        {searchedRackets && searchedRackets.map(racket => (
-                          <>
-                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {racket.racket_image.file_path
-                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-                      </div>
-
-                      <Pagination
-                        paginator={racketsPaginator}
-                        paginate={getSearchedRacketsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-                  </div>
-                </div>
-
+                <RacketSearchModal
+                  modalVisibility={racketSearchModalVisibility}
+                  setModalVisibility={setRacketSearchModalVisibility}
+                  makers={makers}
+                  selectRacketHandler={selectRacket}
+                  showingResult={true}
+                  searchedRackets={searchedRackets}
+                  setSearchedRackets={setSearchedRackets}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputRacketSearchWord}
+                  setInputSearchWord={setInputRacketSearchWord}
+                  inputSearchMaker={inputRacketSearchMaker}
+                  setInputSearchMaker={setInputRacketSearchMaker}
+                />
               </div>
             </div>
           </>

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -115,6 +115,14 @@ const ReviewList = () => {
     setCrossGut,
     racket,
     setRacket,
+    inputGutSearchWord,
+    setInputGutSearchWord,
+    inputGutSearchMaker,
+    setInputGutSearchMaker,
+    inputRacketSearchWord,
+    setInputRacketSearchWord,
+    inputRacketSearchMaker,
+    setInputRacketSearchMaker,
 
     experiencePeriod,
     frequency,
@@ -823,6 +831,10 @@ const ReviewList = () => {
                 searchedGuts={searchedGuts}
                 setSearchedGuts={setSearchedGuts}
                 zIndexClassName="z-50"
+                inputSearchWord={inputGutSearchWord}
+                setInputSearchWord={setInputGutSearchWord}
+                inputSearchMaker={inputGutSearchMaker}
+                setInputSearchMaker={setInputGutSearchMaker}
               />
 
               <RacketSearchModal
@@ -835,6 +847,10 @@ const ReviewList = () => {
                 searchedRackets={searchedRackets}
                 setSearchedRackets={setSearchedRackets}
                 zIndexClassName="z-50"
+                inputSearchWord={inputRacketSearchWord}
+                setInputSearchWord={setInputRacketSearchWord}
+                inputSearchMaker={inputRacketSearchMaker}
+                setInputSearchMaker={setInputRacketSearchMaker}
               />
 
             </div>

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -18,6 +18,9 @@ import { IoClose } from "react-icons/io5";
 import Pagination, { Paginator } from "@/components/Pagination";
 import EvaluationRangeItem from "@/components/EvaluationRangeItem";
 import MyEquipmentCard from "@/components/MyEquipmentCard";
+import GutSearchModal from "@/components/GutSearchModal";
+import RacketSearchModal from "@/components/RacketSearchModal";
+
 import { getToday } from "@/modules/getToday";
 
 type PostingGutReviewData = {
@@ -83,56 +86,39 @@ const GutReviewRegister: NextPage = () => {
   const [inputNewGutDate, setInputNewGutDate] = useState<string>(today);
 
   //モーダルの開閉に関するstate
-  const [modalVisibility, setModalVisibility] = useState<boolean>(false);
-
-  const [modalVisibilityClassName, setModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
+  const [gutSearchModalVisibility, setGutSearchModalVisibility] = useState<boolean>(false);
 
   const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
-
-  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   const [myEquipmentSearchModalVisibility, setMyEquipmentModalVisibility] = useState<boolean>(false);
 
   const [myEquipmentSearchModalVisibilityClassName, setMyEquipmentSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   //検索関連のstate
-  const [inputSearchWord, setInputSearchWord] = useState<string>('');
-
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  const [inputGutSearchWord, setInputGutSearchWord] = useState<string>('');
+  const [inputGutSearchMaker, setInputGutSearchMaker] = useState<number>();
+  const [inputRacketSearchWord, setInputRacketSearchWord] = useState<string>('');
+  const [inputRacketSearchMaker, setInputRacketSearchMaker] = useState<number>();
 
   const [searchedGuts, setSearchedGuts] = useState<Gut[]>();
 
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
 
-  const [gutsPaginator, setGutsPaginator] = useState<Paginator<Gut>>();
-
-  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
-
   const [searchedMyEquipments, setSearchedEquipments] = useState<MyEquipment[]>();
-  console.log('searchedMyEquipments', searchedMyEquipments)
+
   const [myEquipmentsPaginator, setMyEquipmentsPaginator] = useState<Paginator<MyEquipment>>();
-  console.log('myEquipmentsPaginator', myEquipmentsPaginator)
 
   // myEquipment検索state群
   const [inputMyEquipmentSearchWord, setInputMyEquipmentSearchWord] = useState<string>('');
-  console.log('inputMyEquipmentSearchWord', inputMyEquipmentSearchWord)
   const [inputMyEquipmentSearchStringingWay, setInputMyEquipmentSearchStringingWay] = useState<string>('');
-  console.log('inputMyEquipmentSearchStringingWay', inputMyEquipmentSearchStringingWay)
   const [inputMyEquipmentSearchDate, setInputMyEquipmentSearchDate] = useState<string>(today);
-  console.log('inputMyEquipmentSearchDate', inputMyEquipmentSearchDate)
   const [inputMyEquipmentSearchDateRangeType, setInputMyEquipmentSearchDateRangeType] = useState<string>('or_less');
-  console.log('inputMyEquipmentSearchDateRangeType', inputMyEquipmentSearchDateRangeType)
-
 
   // 評価に関するstate
   const [matchRate, setMatchRate] = useState<number>(3);
-  console.log('matchRate', matchRate)
   const [pysicalDurability, setPysicalDurability] = useState<number>(3);
-  console.log('pysicalDurability', pysicalDurability)
   const [performanceDurability, setPerformanceDurability] = useState<number>(3);
-  console.log('performanceDurability', performanceDurability)
   const [reviewComment, setReviewComment] = useState<string>('');
-  console.log('reviewComment', reviewComment)
 
   useEffect(() => {
     const getMakerList = async () => {
@@ -153,12 +139,10 @@ const GutReviewRegister: NextPage = () => {
 
   // gut検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
-    if (modalVisibility) {
-      setModalVisibilityClassName('opacity-100 scale-100')
+    if (gutSearchModalVisibility) {
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -167,16 +151,14 @@ const GutReviewRegister: NextPage = () => {
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
-  }, [modalVisibility])
+  }, [gutSearchModalVisibility])
 
   // racket検索モーダル開閉とその時の縦スクロールの挙動を考慮している
   useEffect(() => {
     if (racketSearchModalVisibility) {
-      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -213,46 +195,37 @@ const GutReviewRegister: NextPage = () => {
 
   const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
+      setInputRacketSearchMaker(undefined);
       return
     };
 
-    setInputSearchMaker(Number(e.target.value));
+    setInputRacketSearchMaker(Number(e.target.value));
   }
 
   //モーダルの開閉
   const closeModal = () => {
-    setModalVisibility(false);
-    setModalVisibilityClassName('opacity-0 scale-0')
+    setGutSearchModalVisibility(false);
     setWitchSelectingGut('');
-  }
-
-  const openModal = () => {
-    setModalVisibilityClassName('opacity-100 scale-100')
   }
 
   //gutを選んだ際、mainGut,crossGutで分けて値をstateにセットさせたかったためopenModalを分けてある
   const openMainGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('main');
   }
 
   const openCrossGutSearchModal = () => {
-    setModalVisibility(true);
-    openModal();
+    setGutSearchModalVisibility(true);
     setWitchSelectingGut('cross');
   }
 
   //gutとは別でracket検索のモーダルが必要であり開閉の処理をgut検索のモーダルとは分離しておく必要があった
   const openRacketSearchModal = () => {
     setRacketSearchModalVisibility(true);
-    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
     setRacketSearchModalVisibility(false)
-    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
   }
 
   // my_equipment検索モーダル開閉
@@ -267,50 +240,6 @@ const GutReviewRegister: NextPage = () => {
   }
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
-
-  //ページネーションを考慮した検索後gut一覧データの取得関数
-  const getSearchedGutsList = async (url: string = `api/guts/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setGutsPaginator(res.data);
-
-      setSearchedGuts(res.data.data);
-    })
-  }
-
-  //gut検索
-  const searchGuts = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      getSearchedGutsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  //ページネーションを考慮した検索後racket一覧データの取得関数
-  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setRacketsPaginator(res.data);
-
-      setSearchedRackets(res.data.data);
-    })
-  }
-
-  //racket検索
-  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-
-    try {
-      getSearchedRacketsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
-  }
 
   //ページネーションを考慮した検索後myEquipment一覧データの取得
   const initialMyEquipmentSearchUrl = `api/my_equipments/user/${user.id}/search?several_words=${inputMyEquipmentSearchWord}&stringing_way=${inputMyEquipmentSearchStringingWay}&search_date=${inputMyEquipmentSearchDate}&date_range_type=${inputMyEquipmentSearchDateRangeType}`;
@@ -807,128 +736,37 @@ const GutReviewRegister: NextPage = () => {
                 </form>
 
                 {/* gut検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${modalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px] overflow-y-auto">
-                    <div onClick={closeModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchGuts} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ストリング　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ガット */}
-                        {searchedGuts && searchedGuts.map(gut => (
-                          <>
-                            <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {gut.gut_image.file_path
-                                  ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                  : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-
-                      </div>
-
-                      <Pagination
-                        paginator={gutsPaginator}
-                        paginate={getSearchedGutsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-
-                  </div>
-                </div>
+                <GutSearchModal
+                  modalVisibility={gutSearchModalVisibility}
+                  setModalVisibility={setGutSearchModalVisibility}
+                  makers={makers}
+                  closeModalHandler={closeModal}
+                  selectGutHandler={selectGut}
+                  showingResult={true}
+                  searchedGuts={searchedGuts}
+                  setSearchedGuts={setSearchedGuts}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputGutSearchWord}
+                  setInputSearchWord={setInputGutSearchWord}
+                  inputSearchMaker={inputGutSearchMaker}
+                  setInputSearchMaker={setInputGutSearchMaker}
+                />
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ラケット */}
-                        {searchedRackets && searchedRackets.map(racket => (
-                          <>
-                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {racket.racket_image.file_path
-                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-                      </div>
-
-                      <Pagination
-                        paginator={racketsPaginator}
-                        paginate={getSearchedRacketsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-                  </div>
-                </div>
+                <RacketSearchModal
+                  modalVisibility={racketSearchModalVisibility}
+                  setModalVisibility={setRacketSearchModalVisibility}
+                  makers={makers}
+                  selectRacketHandler={selectRacket}
+                  showingResult={true}
+                  searchedRackets={searchedRackets}
+                  setSearchedRackets={setSearchedRackets}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputRacketSearchWord}
+                  setInputSearchWord={setInputRacketSearchWord}
+                  inputSearchMaker={inputRacketSearchMaker}
+                  setInputSearchMaker={setInputRacketSearchMaker}
+                />
 
                 {/* my_equipment検索モーダル */}
                 <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${myEquipmentSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>

--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -10,6 +10,7 @@ import AuthCheck from "@/components/AuthCheck";
 import { IoClose } from "react-icons/io5";
 import TextUnderBar from "@/components/TextUnderBar";
 import Pagination, { Paginator } from "@/components/Pagination";
+import RacketSearchModal from "@/components/RacketSearchModal";
 
 //注意：文字列の数字は全角
 export type Frequency = '未設定' | '週１回' | '週２回' | '週３回' | '週４回' | '週５回' | '週６回' | '月１回' | '月２回' | '月３回' | '月４回' | '毎日';
@@ -34,19 +35,15 @@ const TennisProfileEdit: NextPage = () => {
 
   const [racket, setRacket] = useState<Racket>();
 
-  const [racketsPaginator, setRacketsPaginator] = useState<Paginator<Racket>>();
-
   //検索関連のstate
   const [inputSearchWord, setInputSearchWord] = useState<string>('');
 
-  const [inputSearchMaker, setInputSearchMaker] = useState<number | null>();
+  const [inputSearchMaker, setInputSearchMaker] = useState<number>();
 
   const [searchedRackets, setSearchedRackets] = useState<Racket[]>();
 
   //モーダルの開閉に関するstate
   const [racketSearchModalVisibility, setRacketSearchModalVisibility] = useState<boolean>(false);
-
-  const [racketSearchModalVisibilityClassName, setRacketSearchModalVisibilityClassName] = useState<string>('opacity-0 scale-0');
 
   useEffect(() => {
     if (user.id) {
@@ -83,11 +80,9 @@ const TennisProfileEdit: NextPage = () => {
   // racket検索モーダル開閉とその時の背景の縦スクロールの挙動を考慮している
   useEffect(() => {
     if (racketSearchModalVisibility) {
-      setRacketSearchModalVisibilityClassName('opacity-100 scale-100')
       document.body.style.overflow = 'hidden';
       document.documentElement.style.overflow = 'hidden';
     } else {
-      setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
       document.body.style.overflow = 'auto';
       document.documentElement.style.overflow = 'auto';
     }
@@ -98,46 +93,13 @@ const TennisProfileEdit: NextPage = () => {
     }
   }, [racketSearchModalVisibility])
 
-  const onChangeInputSearchMaker = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (e.target.value === '未選択') {
-      setInputSearchMaker(null);
-      return
-    };
-
-    setInputSearchMaker(Number(e.target.value));
-  }
-
   // ラケット検索モーダルの開閉
   const openRacketSearchModal = () => {
     setRacketSearchModalVisibility(true);
-    setRacketSearchModalVisibilityClassName('opacity-100 scale-100');
   }
 
   const closeRacketSearchModal = () => {
     setRacketSearchModalVisibility(false);
-    setRacketSearchModalVisibilityClassName('opacity-0 scale-0');
-  }
-
-  //ページネーションを考慮した検索後racket一覧データの取得関数
-  const getSearchedRacketsList = async (url: string = `api/rackets/search?several_words=${inputSearchWord}&maker=${inputSearchMaker ? inputSearchMaker : ''}`) => {
-    await axios.get(url).then((res) => {
-      setRacketsPaginator(res.data);
-
-      setSearchedRackets(res.data.data);
-    })
-  }
-
-  //racket検索
-  const searchRackets = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-
-    try {
-      getSearchedRacketsList();
-
-      console.log('検索完了しました')
-    } catch (e) {
-      console.log(e);
-    }
   }
 
   const selectRacket = (racket: Racket) => {
@@ -146,7 +108,6 @@ const TennisProfileEdit: NextPage = () => {
   }
 
   const baseImagePath = process.env.NEXT_PUBLIC_BACKEND_URL + '/storage/'
-
 
   const [experiencePeriod, setExperiencePeriod] = useState<number | undefined>();
   const [frequency, setFrequency] = useState<Frequency | undefined>();
@@ -489,66 +450,20 @@ const TennisProfileEdit: NextPage = () => {
                 </div>
 
                 {/* racket検索モーダル */}
-                <div className={`bg-gray-300 w-screen h-screen fixed top-0 left-0 ${racketSearchModalVisibilityClassName} duration-[400ms] pt-[24px] overflow-y-scroll`}>
-                  <div className="flex flex-col items-center w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                    <div onClick={closeRacketSearchModal} className="self-end hover:cursor-pointer md:mr-[39px]">
-                      <IoClose size={48} />
-                    </div>
-
-                    <form action="" onSubmit={searchRackets} className="mb-[24px] md:flex md:mb-[40px]">
-                      <div className="mb-6 md:mb-0 md:mr-[16px]">
-                        <label htmlFor="several_words" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット　検索ワード</label>
-                        <input type="text" name="several_words" onChange={(e) => setInputSearchWord(e.target.value)} className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green" />
-                      </div>
-
-                      <div className="mb-8 md:mb-0 md:mr-[24px]">
-                        <label htmlFor="maker" className="block text-[14px] mb-1 md:text-[16px] md:mb-2">メーカー</label>
-
-                        <select name="maker" id="maker" onChange={(e) => { onChangeInputSearchMaker(e) }} className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green">
-                          <option value="未選択" selected>未選択</option>
-                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                        </select>
-                      </div>
-
-                      <div className="flex justify-end md:justify-start">
-                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                      </div>
-                    </form>
-
-                    {/* 検索結果表示欄 */}
-                    <div className="w-[100%] max-w-[320px] md:max-w-[768px]">
-                      <p className="text-[14px] mb-[16px] md:text-[16px] md:max-w-[640px] md:mx-auto">検索結果</p>
-                      <div className="flex justify-between flex-wrap w-[100%] max-w-[320px] md:max-w-[768px] md:mx-auto">
-                        {/* ラケット */}
-                        {searchedRackets && searchedRackets.map(racket => (
-                          <>
-                            <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
-                              <div className="w-[120px] mr-6">
-                                {racket.racket_image.file_path
-                                  ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                  : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                                }
-                              </div>
-
-                              <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                                <p className="text-[14px] mb-2 md:text-[16px]">{racket.maker.name_ja}</p>
-                                <p className="text-[16px] mb-2 md:text-[18px]">{racket.name_ja}</p>
-                                <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
-                              </div>
-                            </div>
-                          </>
-                        ))}
-                      </div>
-
-                      <Pagination
-                        paginator={racketsPaginator}
-                        paginate={getSearchedRacketsList}
-                        className="mt-[32px] mb-[32px] md:mt-[48px] md:mb-[48px]"
-                      />
-                    </div>
-                  </div>
-                </div>
-
+                <RacketSearchModal
+                  modalVisibility={racketSearchModalVisibility}
+                  setModalVisibility={setRacketSearchModalVisibility}
+                  makers={makers}
+                  selectRacketHandler={selectRacket}
+                  showingResult={true}
+                  searchedRackets={searchedRackets}
+                  setSearchedRackets={setSearchedRackets}
+                  zIndexClassName="z-50"
+                  inputSearchWord={inputSearchWord}
+                  setInputSearchWord={setInputSearchWord}
+                  inputSearchMaker={inputSearchMaker}
+                  setInputSearchMaker={setInputSearchMaker}
+                />
               </div>
             </div>
           </>


### PR DESCRIPTION
issue
#139 

背景：
以前racket及びgut検索モーダルを作成しreview一覧画面一箇所で使用していたが、まだ個別のページでそれぞれモーダルを記述してしまっている箇所が残っているのでそれをコンポーネントを用いたものに修正すれる

確認手順

- [ ] コードのRacketSearchModal.tsxコンポーネントを確認する。
- [ ] このコンポーネントがreview一覧画面の検索でのみ使用されているのが確認できる
- [ ] ほかのラケットサーチモーダルのあるページを確認してみる。tennis_prifileのeditページの検索やmy_equipment登録ページなどではRacketSearchModalコンポーネントを使わずに直書きされていることが確認できる
- [ ] GutSearchModal.tsxコンポーネントに関しても同様に確認できる。

やったこと

- [ ] review関連ページ（register, edit, indexページ）のracket,gut検索モーダルをコンポーネントで書き換えた
 書き換えるにあたり各コンポーネントとReviewContextの修正必要箇所を合わせて修正

- [ ] gut関連ページ（一覧ページ）でのgut検索モーダルをコンポーネントを使って書き換えた
- [ ] racket関連ページ（一覧ページ）でのracket検索モーダルをコンポーネントを使って書き換えた
- [ ] userのtennis_profile更新画面のracket検索モーダルをコンポーネントで書き換えた
- [ ] my_equipment関連ページ（register, editページ）でのracket, gut検索モーダルをコンポーネントを使って書き換えた

備考：
racket, gut一覧ページではspサイズ時の検索モーダルとpcサイズ時での検索欄が別々で用意されているので、pcサイズ時での検索欄のコードを残してある

レビューお願いします