### PR TITLE
modify:#142:gut一覧・詳細、my_equipment詳細ページのspサイズの中心位置のレイアウトの修正

### DIFF
--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -56,7 +56,7 @@ const Gut = () => {
               {/* ガットセクション */}
               <div className="mb-[64px]">
                 <div className="w-[100%] max-w-[320px] mx-auto mb-8 md:max-w-[400px] md:mb-[64px]">
-                  <div className="flex hover:opacity-80 hover:cursor-pointer">
+                  <div className="flex justify-center hover:opacity-80 hover:cursor-pointer">
                     <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
                       {gut?.gut_image.file_path
                         ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
@@ -112,7 +112,7 @@ const Gut = () => {
                   {/* ガット */}
                   {otherGuts && otherGuts.map(otherGut => (
                     <Link href={`/guts/${otherGut.id}`} key={otherGut.id} onClick={() => setId(`${otherGut.id}`)} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
-                      <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                      <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {otherGut.gut_image.file_path
                             ? <img src={`${baseImagePath}${otherGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -165,7 +165,6 @@ const GutList = () => {
               <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
                 {/* ガット */}
                 {guts && guts.map(gut => (
-                  // <Link href={`/guts/${gut.id}`} key={gut.id} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                   <Link href={`/guts/${gut.id}`} key={gut.id} className="hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                     <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                       <div className="w-[120px] mr-6">

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -165,8 +165,9 @@ const GutList = () => {
               <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
                 {/* ガット */}
                 {guts && guts.map(gut => (
-                  <Link href={`/guts/${gut.id}`} key={gut.id} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
-                    <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                  // <Link href={`/guts/${gut.id}`} key={gut.id} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                  <Link href={`/guts/${gut.id}`} key={gut.id} className="hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                    <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                       <div className="w-[120px] mr-6">
                         {gut.gut_image.file_path
                           ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />

--- a/src/pages/my_equipments/[id]/my_equipment.tsx
+++ b/src/pages/my_equipments/[id]/my_equipment.tsx
@@ -48,7 +48,7 @@ const MyEquipment = () => {
 
               <div className="md:flex md:flex-col md:max-h-[700px] md:flex-wrap">
                 {/* ガットセクション */}
-                <div className="mb-8 md:w-[100%] md:max-w-[360px]">
+                <div className="flex flex-col items-center mb-8 md:w-[100%] md:max-w-[360px]">
                   <div className="w-[100%] max-w-[300px] mb-4 md:max-w-[360px]">
                     {myEquipment?.stringing_way === 'hybrid'
                       ? <SubHeading text='ストリング（ハイブリッド張り）' className="text-[16px] w-[100%] max-w-[300px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
@@ -116,7 +116,7 @@ const MyEquipment = () => {
                 </div>
 
                 {/* ラケットセクション */}
-                <div className="mb-8 md:w-[100%] md:max-w-[360px]">
+                <div className="flex flex-col items-center mb-8 md:w-[100%] md:max-w-[360px]">
                   <div className="w-[100%] max-w-[300px] mb-4 md:max-w-[360px]">
                     <SubHeading text='ラケット' className="text-[16px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
                     <TextUnderBar className="w-[100%] max-w-[300px] md:max-w-[360px]" />
@@ -139,10 +139,10 @@ const MyEquipment = () => {
                   </div>
                 </div>
 
-                <TextUnderBar className="w-[100%] max-w-[300px] mb-4 md:hidden" />
+                <TextUnderBar className="w-[100%] max-w-[300px] mb-4 mx-auto md:hidden" />
 
                 {/* ストリング日時セクション */}
-                <div className="mb-8 md:mt-[35px]">
+                <div className="flex flex-col items-center mb-8 md:mt-[35px]">
                   <div className="w-[100%] max-w-[300px] border border-dashed border-black rounded-lg px-2 py-4 md:max-w-[360px] md:min-h-[240px] md:flex md:flex-col md:justify-center md:items-start md:pl-6">
                     <p className="text-[14px] text-right mb-2 md:test-[16px] md:mb-10">張った日：{myEquipment?.new_gut_date}</p>
                     <p className="tracking-tight text-[14px] text-right md:test-[16px] ">ストリング張り替え・切れた日：{myEquipment?.change_gut_date}</p>
@@ -150,12 +150,10 @@ const MyEquipment = () => {
                 </div>
 
                 {/* コメントセクション */}
-                <div>
-                  <div>
-                    <p className="text-[14px] md:text-[16px] md:mb-2">コメント</p>
+                  <div className="flex flex-col items-center">
+                    <p className="text-[14px] text-left w-[100%] max-w-[300px] md:text-[16px] md:mb-2 md:max-w-[360px]">コメント</p>
                     <p className="w-[100%] max-w-[300px] min-h-[160px] border p-2 md:max-w-[360px] md:min-h-[267px]" >{myEquipment?.comment}</p>
                   </div>
-                </div>
               </div>
 
               <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-[24px] md:justify-end md:max-w-[768px]">


### PR DESCRIPTION
### issue
#142 

### 背景
gut一覧,詳細とmy_equipment詳細ページのspサイズ時の中心の整列のレイアウトが左に寄ってしまっているのでそれを修正する

### やったこと

- [ ] gut一覧・詳細ページspサイズのカードの中心整列レイアウト調整
- [ ] my_equipment詳細ページspサイズの各部中心整列レイアウト調整

### 備考：
320pxの時のレイアウトを確認した時に気づいた

レビューお願いします。