### PR TITLE
modify:#145:racket詳細ページのラケット情報表示内容の修正

### DIFF
--- a/src/pages/rackets/[id]/index.tsx
+++ b/src/pages/rackets/[id]/index.tsx
@@ -81,22 +81,18 @@ const RacketShow = () => {
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">メーカー</th>
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ヘッドサイズ</th>
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">重さ</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">長さ</th>
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">バランス</th>
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ストリングパターン</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-y border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">フレーム厚</th>
                     </tr>
                   </thead>
 
                   <tbody className="w-[100%] max-w-[320px] md:max-w-[384px]">
                     <tr className="flex flex-col text-left">
                       <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.maker.name_ja}</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">未登録</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">未登録</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">未登録</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">未登録</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">未登録</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-y border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">未登録</td>
+                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.head_size}平方インチ</td>
+                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.weight ? `${racket?.weight}g` : '未登録' }</td>
+                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.balance ? `${racket?.balance}mm` : '未登録' }</td>
+                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.pattern !== '' ? racket?.pattern : '未登録' }</td>
                     </tr>
                   </tbody>
                 </table>


### PR DESCRIPTION
issue
#145 

背景
今までは、メーカー名とラケット名のみを表示し残りの項目を仮の値としてきたが、racketsテーブルのカラム追加により必要となる表示項目が増えたためそれを表示できる様にする

確認手順

- [ ] ラケット詳細ページに遷移する
- [ ] ラケットの情報がメーカー名とラケット名のみ表示されており、他は仮の値となっていることが確認できる

やったこと


- [ ] ラケット詳細ページのラケット情報表示を仮の値として表示させていたところを実際の値に置き換えた

備考
特になし

レビューお願いします。