### PR TITLE
modify:#149:gutレビュー登録及びマイ装備登録ページの選択ラケットの初期値を修正

### DIFF
--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -88,6 +88,9 @@ const MyEquipmentRegister: NextPage = () => {
     const getUserTennisProfile = async () => {
       await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
         setUserTennisProfile(res.data);
+        if(res.data.racket) {
+          setRacket(res.data.racket);
+        }
       })
     }
 

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -137,6 +137,9 @@ const GutReviewRegister: NextPage = () => {
     const getUserTennisProfile = async () => {
       await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
         setUserTennisProfile(res.data);
+        if(res.data.racket) {
+          setRacket(res.data.racket);
+        }
       })
     }
 


### PR DESCRIPTION
### issue
#149 

### 背景
レビュー登録及びマイ装備登録ページでのラケットの選択が初期値がからの状態であり、テニスプロフィールにラケットを登録してあったとしても再度選ぶ手間が生じている。これの手間をなくしたい

### 確認手順

- [ ] ストリングレビュー登録ページに遷移する
- [ ] 選択ラケットの初期値が空であることが確認できる
- [ ] 続いてマイ装備登録ページに遷移する
- [ ] 選択ラケットの初期値が空であることが確認できる

### やったこと

- [ ] ストリングレビュー登録ページで選択ラケットの初期値をtennis_profileのラケットが登録してあればそれを初期値になる様に修正
- [ ] マイ装備登録ページで選択ラケットの初期値をtennis_profileのラケットが登録してあればそれを初期値になる様に修正

### 備考
特になし

レビューお願いします