### PR TITLE
modify:各ページの画像表示の調整

### DIFF
--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -27,7 +27,7 @@ const MyEquipmentList = () => {
       setMyEquipments(res.data.data);
     })
   }
-  
+
   useEffect(() => {
     if (user.id) {
       getMyEquipmentListOfUser();
@@ -63,9 +63,8 @@ const MyEquipmentList = () => {
                                   <div className="mr-8">
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
-                                        {myEquipment.main_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                        {myEquipment.main_gut.gut_image.file_path &&
+                                          <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -83,9 +82,8 @@ const MyEquipmentList = () => {
 
                                   <div>
                                     <div className="w-[92px] flex flex-col items-center">
-                                      {myEquipment.main_gut.gut_image.file_path
-                                        ? <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[60px] h-[92px] mb-4" />
-                                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                      {myEquipment.racket.racket_image.file_path &&
+                                        <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
                                       }
                                       <div className="text-center">
                                         <p className="h-[16px] text-[14px] mb-4">{myEquipment.racket.maker.name_ja}</p>
@@ -103,9 +101,8 @@ const MyEquipmentList = () => {
                                   <div className="mr-[18px]">
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
-                                        {myEquipment.main_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                        {myEquipment.main_gut.gut_image.file_path && 
+                                          <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -124,9 +121,8 @@ const MyEquipmentList = () => {
                                   <div className="mr-[18px]">
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
-                                        {myEquipment.main_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
+                                        {myEquipment.cross_gut.gut_image.file_path &&
+                                          <img src={`${baseImagePath}${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -144,9 +140,8 @@ const MyEquipmentList = () => {
 
                                   <div>
                                     <div className="w-[92px] flex flex-col items-center">
-                                      {myEquipment.main_gut.gut_image.file_path
-                                        ? <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[60px] h-[92px] mb-4" />
-                                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                      {myEquipment.racket.racket_image.file_path &&
+                                        <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
                                       }
 
                                       <div className="text-center">

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -349,7 +349,7 @@ const MyEquipmentRegister: NextPage = () => {
                             <div className="w-[120px] mr-6">
                               {mainGut && mainGut.gut_image.file_path
                                 ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <div className="w-[120px] h-[120px] border"></div>
                               }
                             </div>
 
@@ -383,7 +383,7 @@ const MyEquipmentRegister: NextPage = () => {
                                 <div className="w-[120px] mr-6">
                                   {crossGut && crossGut.gut_image.file_path
                                     ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <div className="w-[120px] h-[120px] border"></div>
                                   }
                                 </div>
 

--- a/src/pages/rackets/[id]/index.tsx
+++ b/src/pages/rackets/[id]/index.tsx
@@ -60,7 +60,7 @@ const RacketShow = () => {
                 <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
                   {racket?.racket_image.file_path
                     ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px] md:w-[160px] md:h-[200px]" />
-                    : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[160px] md:w-[160px] md:h-[200px]" />
+                    : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                   }
                 </div>
 
@@ -118,7 +118,7 @@ const RacketShow = () => {
                       <div className="w-[120px] mr-6">
                         {otherRacket.racket_image.file_path
                           ? <img src={`${baseImagePath}${otherRacket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
-                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[160px]" />
+                          : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                         }
                       </div>
 

--- a/src/pages/rackets/index.tsx
+++ b/src/pages/rackets/index.tsx
@@ -182,7 +182,7 @@ const RacketList = () => {
                         <div className="w-[120px] mr-6">
                           {racket.racket_image.file_path
                             ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
-                            : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                           }
                         </div>
 

--- a/src/pages/reviews/[id]/review.tsx
+++ b/src/pages/reviews/[id]/review.tsx
@@ -44,10 +44,8 @@ const Review = () => {
                   <div className="flex w-[360px] justify-center mb-6 py-2 md:mr-[32px]">
                     <div className="w-[120px] mr-[24px] md:w-[140px]">
                       {review?.my_equipment.stringing_way === 'hybrid' && <p className="text-[12px] basis-full md:text-[14px] md:mb-2">メイン</p>}
-                      {/* <p className="text-[12px] basis-full">メイン</p> */}
-                      {review?.my_equipment.main_gut.gut_image.file_path
-                        ? <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
-                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="テニスストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
+                      {review?.my_equipment.main_gut.gut_image.file_path &&
+                        <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
                       }
                     </div>
 
@@ -77,9 +75,8 @@ const Review = () => {
                     <div className="flex w-[360px] justify-center mb-6 py-2">
                       <div className="w-[120px] mr-[24px] md:w-[140px]">
                         <p className="text-[12px] basis-full md:text-[14px] md:mb-2">クロス</p>
-                        {review?.my_equipment.main_gut.gut_image.file_path
-                          ? <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
-                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="テニスストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
+                        {review?.my_equipment.cross_gut.gut_image.file_path &&
+                          <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
                         }
                       </div>
 
@@ -104,8 +101,8 @@ const Review = () => {
                 <div className="mb-[32px] w-[360px] md:flex md:justify-center md:basis-full md:w-full">
                   <div className="w-16 mx-auto mb-[10px] md:w-[100px] md:mr-[56px] md:mx-0">
                     {review?.my_equipment.user.file_path
-                      ? <img src={`${baseImagePath}${user.file_path}`} alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full mb-2 md:w-[100px] md:h-[100px]" />
-                      : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full mb-2 md:w-[100px] md:h-[100px]" />
+                      ? <img src={`${baseImagePath}${user.file_path}`} alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full border mb-2 md:w-[100px] md:h-[100px]" />
+                      : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
                     }
 
                     <p className="text-[10px] text-center w-full h-[12px] mb-2 md:text-[16px] md:h-[18px]">{review?.my_equipment.user.name}</p>
@@ -132,7 +129,6 @@ const Review = () => {
                 </div>
 
                 {/* 評価値 */}
-                {/* <div className="w-[320px] mb-6"> */}
                 <div className="w-[320px] md:flex md:justify-between md:w-[768px] ">
                   <div className="mb-6 w-[320px] md:w-[360px]  md:mb-0 md:pt-[24px]">
                     <div className="flex justify-end mb-2">

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -406,7 +406,7 @@ const ReviewList = () => {
                                       <div className="w-16">
                                         {review.my_equipment.user.file_path
                                           ? <img src={`${baseImagePath}${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                          : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
                                         }
 
                                         <p className="text-[10px] text-center w-full h-[12px] mb-2">{review.my_equipment.user.name}</p>
@@ -425,9 +425,8 @@ const ReviewList = () => {
                                   <div>
                                     <div className="w-[92px] h-full flex flex-col justify-center items-start">
                                       <div className="w-[92px]">
-                                        {review.my_equipment.main_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                        {review.my_equipment.main_gut.gut_image.file_path &&
+                                          <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -455,7 +454,7 @@ const ReviewList = () => {
                                       <div className="w-16">
                                         {review.my_equipment.user.file_path
                                           ? <img src={`${baseImagePath}${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                          : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
                                         }
 
                                         <p className="text-[10px] text-center w-full h-[12px] mb-2">{review.my_equipment.user.name}</p>
@@ -474,9 +473,8 @@ const ReviewList = () => {
                                   <div className="mr-4">
                                     <div className="w-[92px] flex flex-col justify-center items-start">
                                       <div className="w-[92px]">
-                                        {review.my_equipment.main_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                        {review.my_equipment.main_gut.gut_image.file_path &&
+                                          <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -495,9 +493,8 @@ const ReviewList = () => {
                                   <div>
                                     <div className="w-[92px] h-[92px] flex flex-col justify-start items-start mb-10">
                                       <div className="w-[92px]">
-                                        {review.my_equipment.cross_gut.gut_image.file_path
-                                          ? <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                        {review.my_equipment.cross_gut.gut_image.file_path &&
+                                          <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 

--- a/src/pages/users/[id]/edit/base_profile.tsx
+++ b/src/pages/users/[id]/edit/base_profile.tsx
@@ -174,10 +174,10 @@ const BaseProfileEdit: NextPage = () => {
                   <hr className=" border-sub-green mb-6" />
 
                   <div className="w-16 md:w-20 mx-auto mb-4">
-                    <div className="w-[64px] h-[64px] rounded-full overflow-hidden mb-2 md:w-[80px] md:h-[80px]">
+                    <div className="w-[64px] h-[64px] border rounded-full overflow-hidden mb-2 md:w-[80px] md:h-[80px]">
                       {user.file_path
                         ? <img src={`${baseImagePath}${user.file_path}`} alt="ユーザープロフィール画像" className=" w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
-                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
+                        : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
                       }
                     </div>
                     <div className="w-8 h-1 bg-sub-green mx-auto"></div>

--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -119,10 +119,10 @@ const UserProfile: NextPage = () => {
                   <hr className=" border-sub-green mb-6" />
 
                   <div className="w-16 mx-auto mb-4">
-                    <div className="w-[64px] h-[64px] rounded-full overflow-hidden mb-2">
+                    <div className="w-[64px] h-[64px] rounded-full overflow-hidden mb-2 border">
                       {user.file_path
                         ? <img src={`${baseImagePath}${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
-                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="" />
+                        : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="" />
                       }
                     </div>
                     <div className="w-8 h-1 bg-sub-green mx-auto"></div>


### PR DESCRIPTION
### issue
#151 

### 背景
ユーザー画像とストリング画像のデフォルト画像を作成したので、関連する画像表示の調整をする

### 確認手順

- [ ] 各ページの表示画像が仮のものになっているのを確認する

### やったこと

- [ ] ユーザープロフィール関連ページの表示画像の修正
- [ ] my_equipment関連ページの画像の表示調整
- [ ] review関連ページの画像表示の調整
- [ ] racket関連ページの画像表示の修正

### 備考

- ストリングの画像に関しては必ず初期画像が登録されているので既存で書いていたコードをそれに合わせて修正している
- ラケット画像についてはラケット登録はユーザーが行いその時に画像を必ず登録する様になっているのでその様にコードを修正している
- ユーザー画像は登録されていなければデフォルトの画像をバックエンドに直接鶏肉用に記述してある

レビューお願いします