### PR TITLE
modify: 各ページで表示させていた画像をamazon s3から取ってくる様に修正

### DIFF
--- a/src/components/GutSearchModal.tsx
+++ b/src/components/GutSearchModal.tsx
@@ -178,8 +178,8 @@ const GutSearchModal: React.FC<GutSearchModalProps> = ({
                       <div onClick={() => selectGut(gut)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {gut.gut_image.file_path
-                            ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                            : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            ? <img src={`${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            : <img src={`${baseImagePath}images/guts/default_gut_image.png`} alt="ストリング画像" className="w-[120px] h-[120px]" />
                           }
                         </div>
 

--- a/src/components/MyEquipmentCard.tsx
+++ b/src/components/MyEquipmentCard.tsx
@@ -26,7 +26,7 @@ const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({
                 <div className="w-[96px] flex flex-col justify-start items-start">
                   <div className="w-[96px] mb-1">
                     {myEquipment.main_gut.gut_image.file_path
-                      && <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
+                      && <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
                     }
                   </div>
 
@@ -46,7 +46,7 @@ const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({
               <div className="flex flex-col items-center w-[96px]">
                 <div className="w-[72px] flex flex-col items-center mb-1">
                   {myEquipment.racket.racket_image.file_path
-                    ? <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[72px] h-[96px]" />
+                    ? <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[72px] h-[96px]" />
                     : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[72px] h-[96px]" />
                   }
                 </div>
@@ -68,7 +68,7 @@ const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({
                 <div className="w-[96px] flex flex-col justify-start items-start ">
                   <div className="w-[96px] mb-1">
                     {myEquipment.main_gut.gut_image.file_path
-                      && <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
+                      && <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
                     }
                   </div>
 
@@ -88,7 +88,7 @@ const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({
                 <div className="w-[96px] flex flex-col justify-start items-start">
                   <div className="w-[96px] mb-1">
                     {myEquipment.cross_gut.gut_image.file_path
-                      && <img src={`${baseImagePath}${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
+                      && <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[96px] h-[96px]" />
                     }
                   </div>
 
@@ -108,7 +108,7 @@ const MyEquipmentCard: React.FC<MyEquipmentCardProps> = ({
               <div className="flex flex-col items-center w-[96px]">
                 <div className="w-[72px] flex flex-col items-center mb-1">
                   {myEquipment.racket.racket_image.file_path
-                    ? <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[72px] h-[96px]" />
+                    ? <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[72px] h-[96px]" />
                     : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[72px] h-[96px]" />
                   }
                 </div>

--- a/src/components/RacketSearchModal.tsx
+++ b/src/components/RacketSearchModal.tsx
@@ -198,8 +198,8 @@ const RacketSearchModal: React.FC<RacketSearchModalProps> = ({
                       <div onClick={() => selectRacket(racket)} className="flex  mb-6 hover:opacity-80 hover:cursor-pointer w-[100%] max-w-[360px] bg-white rounded-lg md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {racket.racket_image.file_path
-                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                            : <img src={`${baseImagePath}images/rackets/defalt_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            ? <img src={`${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                           }
                         </div>
 

--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -247,8 +247,8 @@ const GutEdit: NextPage = () => {
                         </div>
 
                         <div className="w-[100%] max-w-[200px] h-[120px] flex justify-center md:h-[160px] md:max-w-[] md:justify-end">
-                          {selectedGutImage && <img src={`${baseImagePath}${selectedGutImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />}
-                          { (currentGut?.gut_image && !selectedGutImage) && <img src={`${baseImagePath}${currentGut?.gut_image.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" /> }
+                          {selectedGutImage && <img src={`${selectedGutImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />}
+                          { (currentGut?.gut_image && !selectedGutImage) && <img src={`${currentGut?.gut_image.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" /> }
                         </div>
                       </div>
                     </div>
@@ -296,10 +296,10 @@ const GutEdit: NextPage = () => {
                           {/* ガット画像情報カード */}
                           <div onClick={() => selectImage(gutImage)} className="bg-white p-2 rounded-lg w-[100%] max-w-[136px] hover:opacity-80 mb-6 hover:cursor-pointer md:[&:not(:last-child)]:mr-[24px]">
                             <div className="w-[120px] mb-2">
-                              {gutImage.file_path && <img src={`${baseImagePath}${gutImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />}
+                              {gutImage.file_path && <img src={`${gutImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />}
                             </div>
 
-                            <p className="text-[14px] mb-1 md:text-[16px]">{gutImage.maker.name_ja}</p>
+                            <p className="text-[14px] mb-1 md:text-[16px]">{gutImage.maker ? gutImage.maker.name_ja : ''}</p>
 
                             <p className="text-[14px] md:text-[16px]">{gutImage.title}</p>
                           </div>

--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -59,8 +59,8 @@ const Gut = () => {
                   <div className="flex justify-center hover:opacity-80 hover:cursor-pointer">
                     <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
                       {gut?.gut_image.file_path
-                        ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
-                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
+                        ? <img src={`${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
+                        : <img src={`${baseImagePath}images/guts/default_gut_image.png`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[160px] md:h-[160px]" />
                       }
                     </div>
 
@@ -115,8 +115,8 @@ const Gut = () => {
                       <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {otherGut.gut_image.file_path
-                            ? <img src={`${baseImagePath}${otherGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                            : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            ? <img src={`${otherGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            : <img src={`${baseImagePath}images/guts/default_gut_image.png`} alt="ストリング画像" className="w-[120px] h-[120px]" />
                           }
                         </div>
 

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -169,8 +169,8 @@ const GutList = () => {
                     <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                       <div className="w-[120px] mr-6">
                         {gut.gut_image.file_path
-                          ? <img src={`${baseImagePath}${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                          ? <img src={`${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                          : <img src={`${baseImagePath}images/guts/defalt_gut_image.png`} alt="ストリング画像" className="w-[120px] h-[120px]" />
                         }
                       </div>
 

--- a/src/pages/guts/register.tsx
+++ b/src/pages/guts/register.tsx
@@ -229,8 +229,8 @@ const GutRegister: NextPage = () => {
 
                         <div className="w-[100%] max-w-[200px] h-[120px] flex justify-center md:h-[160px] md:max-w-[] md:justify-end">
                           {selectedGutImage
-                            ? <img src={`${baseImagePath}${selectedGutImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />
-                            : <img src={`${baseImagePath}images/guts/default_gut.jpg`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />
+                            ? <img src={`${selectedGutImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />
+                            : <img src={`${baseImagePath}images/guts/default_gut_image.png`} alt="" className="w-[100%] max-w-[120px] border md:max-w-[160px]" />
                           }
                         </div>
                       </div>
@@ -279,10 +279,10 @@ const GutRegister: NextPage = () => {
                           {/* ガット画像情報カード */}
                           <div onClick={() => selectImage(gutImage)} className="bg-white p-2 rounded-lg w-[100%] max-w-[136px] hover:opacity-80 mb-6 hover:cursor-pointer md:[&:not(:last-child)]:mr-[24px]">
                             <div className="w-[120px] mb-2">
-                              {gutImage.file_path && <img src={`${baseImagePath}${gutImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />}
+                              {gutImage.file_path && <img src={`${gutImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />}
                             </div>
 
-                            <p className="text-[14px] mb-1 md:text-[16px]">{gutImage.maker.name_ja}</p>
+                            <p className="text-[14px] mb-1 md:text-[16px]">{gutImage.maker ? gutImage.maker.name_ja : ''}</p>
 
                             <p className="text-[14px] md:text-[16px]">{gutImage.title}</p>
                           </div>

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -350,8 +350,8 @@ const MyEquipmentEdit: NextPage = () => {
                           <div className="flex md:w-[100%] md:max-w-[360px]">
                             <div className="w-[120px] mr-6">
                               {mainGut && mainGut.gut_image.file_path
-                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                ? <img src={`${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <div className="w-[120px] h-[120px] border"></div>
                               }
                             </div>
 
@@ -384,8 +384,8 @@ const MyEquipmentEdit: NextPage = () => {
                               <div className="flex md:w-[100%] md:max-w-[360px]">
                                 <div className="w-[120px] mr-6">
                                   {crossGut && crossGut.gut_image.file_path
-                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    ? <img src={`${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <div className="w-[120px] h-[120px] border"></div>
                                   }
                                 </div>
 
@@ -537,8 +537,8 @@ const MyEquipmentEdit: NextPage = () => {
                       <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {racket && racket.racket_image.file_path
-                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            ? <img src={`${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <div className="w-[120px] h-[160px] border"></div>
                           }
                         </div>
 

--- a/src/pages/my_equipments/[id]/my_equipment.tsx
+++ b/src/pages/my_equipments/[id]/my_equipment.tsx
@@ -39,7 +39,6 @@ const MyEquipment = () => {
     <>
       <AuthCheck>
         {isAuth && (
-          // <h1>マイ装備詳細</h1>
           <div className="container mb-8 mx-auto">
             <div className=" w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
               <div className="text-center my-6 md:mb-[32px]">
@@ -64,8 +63,8 @@ const MyEquipment = () => {
                       <div className="md:mr-[24px]">
                         <p className="text-[14px] md:text-[16px]">メイン</p>
                         {myEquipment?.main_gut.gut_image.file_path
-                          ? <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
-                          : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
+                          ? <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
+                          : <div className="w-[120px] h-[120px] border"></div>
                         }
                       </div>
 
@@ -96,9 +95,9 @@ const MyEquipment = () => {
                         <div className="ml-[48px] md:ml-0 md:flex">
                           <div className="md:mr-[24px]">
                             <p className="text-[14px] md:text-[16px]">クロス</p>
-                            {myEquipment?.main_gut.gut_image.file_path
-                              ? <img src={`${baseImagePath}${myEquipment.cross_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
-                              : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
+                            {myEquipment?.cross_gut.gut_image.file_path
+                              ? <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
+                              : <div className="w-[120px] h-[120px] border"></div>
                             }
                           </div>
 
@@ -126,8 +125,8 @@ const MyEquipment = () => {
                   <div className="flex justify-center md:justify-start">
                     <div className="mr-[24px]">
                       {myEquipment?.racket.racket_image.file_path
-                        ? <img src={`${baseImagePath}${myEquipment?.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[92px] h-[132px] mb-1 md:w-[120px] md:h-[160px] md:mb-0" />
-                        : <img src={`${baseImagePath}images/users/defalt_user_image.jpg`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[92px] h-[132px] mb-1 md:w-[120px] md:h-[160px] md:mb-0" />
+                        ? <img src={`${myEquipment?.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[92px] h-[132px] mb-1 md:w-[120px] md:h-[160px] md:mb-0" />
+                        : <div className="w-[120px] h-[160px] border"></div>
                       }
                     </div>
 

--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -64,7 +64,7 @@ const MyEquipmentList = () => {
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
                                         {myEquipment.main_gut.gut_image.file_path &&
-                                          <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -83,7 +83,7 @@ const MyEquipmentList = () => {
                                   <div>
                                     <div className="w-[92px] flex flex-col items-center">
                                       {myEquipment.racket.racket_image.file_path &&
-                                        <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
+                                        <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
                                       }
                                       <div className="text-center">
                                         <p className="h-[16px] text-[14px] mb-4">{myEquipment.racket.maker.name_ja}</p>
@@ -102,7 +102,7 @@ const MyEquipmentList = () => {
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
                                         {myEquipment.main_gut.gut_image.file_path && 
-                                          <img src={`${baseImagePath}${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -122,7 +122,7 @@ const MyEquipmentList = () => {
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
                                         {myEquipment.cross_gut.gut_image.file_path &&
-                                          <img src={`${baseImagePath}${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -141,7 +141,7 @@ const MyEquipmentList = () => {
                                   <div>
                                     <div className="w-[92px] flex flex-col items-center">
                                       {myEquipment.racket.racket_image.file_path &&
-                                        <img src={`${baseImagePath}${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
+                                        <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
                                       }
 
                                       <div className="text-center">

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -348,7 +348,7 @@ const MyEquipmentRegister: NextPage = () => {
                           <div className="flex md:w-[100%] md:max-w-[360px]">
                             <div className="w-[120px] mr-6">
                               {mainGut && mainGut.gut_image.file_path
-                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                ? <img src={`${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
                                 : <div className="w-[120px] h-[120px] border"></div>
                               }
                             </div>
@@ -382,7 +382,7 @@ const MyEquipmentRegister: NextPage = () => {
                               <div className="flex md:w-[100%] md:max-w-[360px]">
                                 <div className="w-[120px] mr-6">
                                   {crossGut && crossGut.gut_image.file_path
-                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    ? <img src={`${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
                                     : <div className="w-[120px] h-[120px] border"></div>
                                   }
                                 </div>
@@ -534,8 +534,8 @@ const MyEquipmentRegister: NextPage = () => {
                       <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {racket && racket.racket_image.file_path
-                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            ? <img src={`${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <div className="w-[120px] h-[160px] border"></div>
                           }
                         </div>
 

--- a/src/pages/rackets/[id]/edit.tsx
+++ b/src/pages/rackets/[id]/edit.tsx
@@ -446,8 +446,8 @@ const RacketEdit: NextPage = () => {
                         </div>
 
                         <div className="w-[100%] max-w-[200px] h-[160px] flex justify-center md:justify-end">
-                          {selectedRacketImage && <img src={`${baseImagePath}${selectedRacketImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] h-[160px] border" />}
-                          {(currentRacket?.racket_image && !selectedRacketImage) && <img src={`${baseImagePath}${currentRacket?.racket_image.file_path}`} alt="" className="w-[100%] max-w-[120px] h-[160px] border " />}
+                          {selectedRacketImage && <img src={`${selectedRacketImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] h-[160px] border" />}
+                          {(currentRacket?.racket_image && !selectedRacketImage) && <img src={`${currentRacket?.racket_image.file_path}`} alt="" className="w-[100%] max-w-[120px] h-[160px] border " />}
                         </div>
                       </div>
                     </div>
@@ -495,7 +495,7 @@ const RacketEdit: NextPage = () => {
                           {/* ガット画像情報カード */}
                           <div onClick={() => selectImage(racketImage)} className="bg-white p-2 rounded-lg w-[100%] max-w-[136px] hover:opacity-80 mb-6 hover:cursor-pointer md:[&:not(:last-child)]:mr-[24px]">
                             <div className="w-[120px] mb-2">
-                              {racketImage.file_path && <img src={`${baseImagePath}${racketImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />}
+                              {racketImage.file_path && <img src={`${racketImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />}
                             </div>
 
                             <p className="text-[14px] mb-1 md:text-[16px]">{racketImage.maker.name_ja}</p>

--- a/src/pages/rackets/[id]/index.tsx
+++ b/src/pages/rackets/[id]/index.tsx
@@ -59,7 +59,7 @@ const RacketShow = () => {
               <div className="flex md:w-[100%] md:max-w-[400px]">
                 <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
                   {racket?.racket_image.file_path
-                    ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px] md:w-[160px] md:h-[200px]" />
+                    ? <img src={`${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px] md:w-[160px] md:h-[200px]" />
                     : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                   }
                 </div>
@@ -117,7 +117,7 @@ const RacketShow = () => {
                     <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                       <div className="w-[120px] mr-6">
                         {otherRacket.racket_image.file_path
-                          ? <img src={`${baseImagePath}${otherRacket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
+                          ? <img src={`${otherRacket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
                           : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                         }
                       </div>

--- a/src/pages/rackets/index.tsx
+++ b/src/pages/rackets/index.tsx
@@ -181,7 +181,7 @@ const RacketList = () => {
                       <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {racket.racket_image.file_path
-                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
+                            ? <img src={`${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
                             : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                           }
                         </div>

--- a/src/pages/rackets/register.tsx
+++ b/src/pages/rackets/register.tsx
@@ -224,8 +224,8 @@ const RacketRegister: NextPage = () => {
 
                         <div className="w-[100%] max-w-[200px] h-[160px] flex justify-center md:h-[200px] md:justify-end">
                           {selectedRacketImage
-                            ? <img src={`${baseImagePath}${selectedRacketImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] h-[160px] border md:max-w-[150px] md:h-[200px]" />
-                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="" className="w-[100%] max-w-[120px] h-[160px] border md:max-w-[150px] md:h-[200px]" />
+                            ? <img src={`${selectedRacketImage?.file_path}`} alt="" className="w-[100%] max-w-[120px] h-[160px] border md:max-w-[150px] md:h-[200px]" />
+                            : <div className="w-[120px] h-[160px] border md:w-[150px] md:h-[200px]"></div>
                           }
                         </div>
                       </div>
@@ -274,7 +274,7 @@ const RacketRegister: NextPage = () => {
                           {/* ラケット画像情報カード */}
                           <div key={racketImage.id} onClick={() => selectImage(racketImage)} className="bg-white p-2 rounded-lg w-[100%] max-w-[136px] hover:opacity-80 mb-6 hover:cursor-pointer md:[&:not(:last-child)]:mr-[24px]">
                             <div className="w-[120px] mb-2">
-                              {racketImage.file_path && <img src={`${baseImagePath}${racketImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />}
+                              {racketImage.file_path && <img src={`${racketImage.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />}
                             </div>
 
                             <p className="text-[14px] mb-1 md:text-[16px]">{racketImage.maker.name_ja}</p>

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -407,8 +407,8 @@ const GutReviewEdit: NextPage = () => {
                           <div className="flex md:w-[100%] md:max-w-[360px]">
                             <div className="w-[120px] mr-6">
                               {mainGut && mainGut.gut_image.file_path
-                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                ? <img src={`${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <div className="w-[120px] h-[120px] border"></div>
                               }
                             </div>
 
@@ -444,8 +444,8 @@ const GutReviewEdit: NextPage = () => {
                               <div className="flex md:w-[100%] md:max-w-[360px]">
                                 <div className="w-[120px] mr-6">
                                   {crossGut && crossGut.gut_image.file_path
-                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    ? <img src={`${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <div className="w-[120px] h-[120px] border"></div>
                                   }
                                 </div>
 
@@ -564,8 +564,8 @@ const GutReviewEdit: NextPage = () => {
                       <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {racket && racket.racket_image.file_path
-                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            ? <img src={`${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <div className="w-[120px] h-[160px] border"></div>
                           }
                         </div>
 

--- a/src/pages/reviews/[id]/review.tsx
+++ b/src/pages/reviews/[id]/review.tsx
@@ -45,7 +45,7 @@ const Review = () => {
                     <div className="w-[120px] mr-[24px] md:w-[140px]">
                       {review?.my_equipment.stringing_way === 'hybrid' && <p className="text-[12px] basis-full md:text-[14px] md:mb-2">メイン</p>}
                       {review?.my_equipment.main_gut.gut_image.file_path &&
-                        <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
+                        <img src={`${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
                       }
                     </div>
 
@@ -76,7 +76,7 @@ const Review = () => {
                       <div className="w-[120px] mr-[24px] md:w-[140px]">
                         <p className="text-[12px] basis-full md:text-[14px] md:mb-2">クロス</p>
                         {review?.my_equipment.cross_gut.gut_image.file_path &&
-                          <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
+                          <img src={`${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px] md:w-[140px] md:h-[140px]" />
                         }
                       </div>
 
@@ -101,7 +101,7 @@ const Review = () => {
                 <div className="mb-[32px] w-[360px] md:flex md:justify-center md:basis-full md:w-full">
                   <div className="w-16 mx-auto mb-[10px] md:w-[100px] md:mr-[56px] md:mx-0">
                     {review?.my_equipment.user.file_path
-                      ? <img src={`${baseImagePath}${user.file_path}`} alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full border mb-2 md:w-[100px] md:h-[100px]" />
+                      ? <img src={`${review?.my_equipment.user.file_path}`} alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full border mb-2 md:w-[100px] md:h-[100px]" />
                       : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
                     }
 

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -405,7 +405,7 @@ const ReviewList = () => {
                                     <div className="w-[92px] h-[92px] flex justify-center items-center mb-10">
                                       <div className="w-16">
                                         {review.my_equipment.user.file_path
-                                          ? <img src={`${baseImagePath}${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                          ? <img src={`${review.my_equipment.user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
                                           : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
                                         }
 
@@ -426,7 +426,7 @@ const ReviewList = () => {
                                     <div className="w-[92px] h-full flex flex-col justify-center items-start">
                                       <div className="w-[92px]">
                                         {review.my_equipment.main_gut.gut_image.file_path &&
-                                          <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -453,7 +453,7 @@ const ReviewList = () => {
                                     <div className="w-[92px] h-[92px] flex justify-center items-center mb-10">
                                       <div className="w-16">
                                         {review.my_equipment.user.file_path
-                                          ? <img src={`${baseImagePath}${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
+                                          ? <img src={`${review.my_equipment.user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
                                           : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
                                         }
 
@@ -474,7 +474,7 @@ const ReviewList = () => {
                                     <div className="w-[92px] flex flex-col justify-center items-start">
                                       <div className="w-[92px]">
                                         {review.my_equipment.main_gut.gut_image.file_path &&
-                                          <img src={`${baseImagePath}${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${review.my_equipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 
@@ -494,7 +494,7 @@ const ReviewList = () => {
                                     <div className="w-[92px] h-[92px] flex flex-col justify-start items-start mb-10">
                                       <div className="w-[92px]">
                                         {review.my_equipment.cross_gut.gut_image.file_path &&
-                                          <img src={`${baseImagePath}${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${review.my_equipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
                                         }
                                       </div>
 

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -496,8 +496,8 @@ const GutReviewRegister: NextPage = () => {
                           <div className="flex md:w-[100%] md:max-w-[360px]">
                             <div className="w-[120px] mr-6">
                               {mainGut && mainGut.gut_image.file_path
-                                ? <img src={`${baseImagePath}${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                ? <img src={`${mainGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                : <div className="w-[120px] h-[120px] border"></div>
                               }
                             </div>
 
@@ -534,8 +534,8 @@ const GutReviewRegister: NextPage = () => {
                               <div className="flex md:w-[100%] md:max-w-[360px]">
                                 <div className="w-[120px] mr-6">
                                   {crossGut && crossGut.gut_image.file_path
-                                    ? <img src={`${baseImagePath}${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                                    : <img src={`${baseImagePath}images/guts/default_gut_image.jpg`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    ? <img src={`${crossGut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                                    : <div className="w-[120px] h-[120px] border"></div>
                                   }
                                 </div>
 
@@ -654,8 +654,8 @@ const GutReviewRegister: NextPage = () => {
                       <div className="flex  mb-6 md:w-[100%] md:max-w-[360px]">
                         <div className="w-[120px] mr-6">
                           {racket && racket.racket_image.file_path
-                            ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            ? <img src={`${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                            : <div className="w-[120px] h-[160px] border"></div>
                           }
                         </div>
 

--- a/src/pages/users/[id]/edit/base_profile.tsx
+++ b/src/pages/users/[id]/edit/base_profile.tsx
@@ -176,7 +176,7 @@ const BaseProfileEdit: NextPage = () => {
                   <div className="w-16 md:w-20 mx-auto mb-4">
                     <div className="w-[64px] h-[64px] border rounded-full overflow-hidden mb-2 md:w-[80px] md:h-[80px]">
                       {user.file_path
-                        ? <img src={`${baseImagePath}${user.file_path}`} alt="ユーザープロフィール画像" className=" w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
+                        ? <img src={`${user.file_path}`} alt="ユーザープロフィール画像" className=" w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
                         : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
                       }
                     </div>

--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -326,7 +326,7 @@ const TennisProfileEdit: NextPage = () => {
 
                     <div className="w-[100%] max-w-[120px] h-[160px] bg-faint-green">
                       {racket && racket.racket_image.file_path
-                        ? <img src={`${baseImagePath}${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                        ? <img src={`${racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                         : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                       }
                     </div>

--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -121,7 +121,7 @@ const UserProfile: NextPage = () => {
                   <div className="w-16 mx-auto mb-4">
                     <div className="w-[64px] h-[64px] rounded-full overflow-hidden mb-2 border">
                       {user.file_path
-                        ? <img src={`${baseImagePath}${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
+                        ? <img src={`${user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px]" />
                         : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="" />
                       }
                     </div>
@@ -150,7 +150,7 @@ const UserProfile: NextPage = () => {
 
                     <div className="w-28 h-40 bg-faint-green">
                       { tennisProfile?.racket?.racket_image.file_path
-                        ? <img src={`${baseImagePath}${tennisProfile.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                        ? <img src={`${tennisProfile.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                         : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                       }
                     </div>


### PR DESCRIPTION
### issue
#153 

### 背景
画像ファイルの保存先をバックエンドlaravelのstorageフォルダ下でなくamazon s3に保存する様に変更したため、フロントで画像表示のsrc属性がamazon s3から画像を取得する様に修正する必要がある

### 確認手順

- [ ] 各ページgut、racket、userプロフィールのイメージ表示部分を確認する

- [ ] 以前までのsrc属性で正しいsrcになっておらず表示がされていないことが確認できる

### やったこと

- [ ] user関連ページの画像表示を修正
- [ ] review関連ページの画像表示を修正
- [ ] racket関連ページの画像表示を修正
- [ ] my_equipment関連ページの画像表示を修正
- [ ] gut関連ページの画像表示を修正
- [ ] コンポーネントで使っていた画像表示を修正

### 備考
特になし

レビューお願いします
