### PR TITLE
modify:レビュー及びマイ装備一覧画面のレイアウト崩れの修正

### DIFF
--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -56,26 +56,26 @@ const MyEquipmentList = () => {
                     return (
                       <>
                         <Link href={`/my_equipments/${myEquipment.id}/my_equipment`} className="block max-w-[360px] w-[100%] min-h-[280px] mb-6 md:mb-16">
-                          <div key={myEquipment.id} className="max-w-[360px] w-[100%] min-h-[280px] border border-gray-400 rounded  flex flex-col justify-around py-4 hover:cursor-pointer">
+                          <div key={myEquipment.id} className="max-w-[360px] w-[100%] h-[280px] border border-gray-400 rounded  flex flex-col justify-around py-4 hover:cursor-pointer">
                             {myEquipment.stringing_way === "single" && (
                               <>
-                                <div className=" flex justify-center mb-6">
+                                <div className=" flex justify-center">
                                   <div className="mr-8">
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
                                         {myEquipment.main_gut.gut_image.file_path &&
-                                          <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-1" />
                                         }
                                       </div>
 
                                       <div className="mb-1">
-                                        <p className="h-[16px] text-[14px] mb-2">{myEquipment.main_gut.maker.name_ja}</p>
+                                        <p className="h-[10px] text-[10px] mb-2">{myEquipment.main_gut.maker.name_ja}</p>
                                         <p className="tracking-tighter min-h-[16px] text-[14px]">{myEquipment.main_gut.name_ja}</p>
                                       </div>
 
                                       <div>
-                                        <p className="tracking-tighter h-[16px] text-[14px] mr-auto mb-[4px]">{myEquipment.main_gut_guage.toFixed(2)} / {myEquipment.cross_gut_guage.toFixed(2)} mm</p>
-                                        <p className="tracking-tighter h-[16px] text-[14px] mr-auto">{myEquipment.main_gut_tension} / {myEquipment.cross_gut_tension} ポンド</p>
+                                        <p className="tracking-tighter h-[12px] text-[10px] mr-auto mb-[4px]">{myEquipment.main_gut_guage.toFixed(2)} / {myEquipment.cross_gut_guage.toFixed(2)} mm</p>
+                                        <p className="tracking-tighter h-[12px] text-[10px] mr-auto">{myEquipment.main_gut_tension} / {myEquipment.cross_gut_tension} ポンド</p>
                                       </div>
                                     </div>
                                   </div>
@@ -83,11 +83,11 @@ const MyEquipmentList = () => {
                                   <div>
                                     <div className="w-[92px] flex flex-col items-center">
                                       {myEquipment.racket.racket_image.file_path &&
-                                        <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
+                                        <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-1" />
                                       }
                                       <div className="text-center">
-                                        <p className="h-[16px] text-[14px] mb-4">{myEquipment.racket.maker.name_ja}</p>
-                                        <p className="tracking-tighter break-words min-h-[16px] text-[14px] max-w-[92px] ">{myEquipment.racket.name_ja}</p>
+                                        <p className="h-[10px] text-[10px] mb-2">{myEquipment.racket.maker.name_ja}</p>
+                                        <p className="tracking-tighter break-words min-h-[16px] text-[14px] text-left max-w-[92px] ">{myEquipment.racket.name_ja}</p>
                                       </div>
                                     </div>
                                   </div>
@@ -97,23 +97,23 @@ const MyEquipmentList = () => {
 
                             {myEquipment.stringing_way === "hybrid" && (
                               <>
-                                <div className=" flex justify-center mb-6">
+                                <div className=" flex justify-center">
                                   <div className="mr-[18px]">
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
                                         {myEquipment.main_gut.gut_image.file_path && 
-                                          <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-1" />
                                         }
                                       </div>
 
                                       <div className="mb-1">
-                                        <p className="h-[16px] text-[14px] mb-2">{myEquipment.main_gut.maker.name_ja}</p>
+                                        <p className="h-[10px] text-[10px] mb-2">{myEquipment.main_gut.maker.name_ja}</p>
                                         <p className="tracking-tighter min-h-[16px] text-[14px] ">{myEquipment.main_gut.name_ja}</p>
                                       </div>
 
                                       <div>
-                                        <p className="tracking-tighter h-[16px] text-[14px] mr-auto mb-[4px]">{myEquipment.main_gut_guage.toFixed(2)} mm</p>
-                                        <p className="tracking-tighter h-[16px] text-[14px] mr-auto">{myEquipment.main_gut_tension} ポンド</p>
+                                        <p className="tracking-tighter h-[12px] text-[10px] mr-auto mb-[4px]">{myEquipment.main_gut_guage.toFixed(2)} mm</p>
+                                        <p className="tracking-tighter h-[12px] text-[10px] mr-auto">{myEquipment.main_gut_tension} ポンド</p>
                                       </div>
                                     </div>
                                   </div>
@@ -122,18 +122,18 @@ const MyEquipmentList = () => {
                                     <div className="w-[92px] flex flex-col justify-start items-start ">
                                       <div className="w-[92px]">
                                         {myEquipment.cross_gut.gut_image.file_path &&
-                                          <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-2" />
+                                          <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ストリング画像" className="w-[92px] h-[92px] mb-1" />
                                         }
                                       </div>
 
                                       <div className="mb-1">
-                                        <p className="h-[16px] text-[14px] mb-2">{myEquipment.cross_gut.maker.name_ja}</p>
+                                        <p className="h-[10px] text-[10px] mb-2">{myEquipment.cross_gut.maker.name_ja}</p>
                                         <p className="tracking-tighter min-h-[16px] text-[14px] ">{myEquipment.cross_gut.name_ja}</p>
                                       </div>
 
                                       <div>
-                                        <p className="tracking-tighter h-[16px] text-[14px] mr-auto mb-[4px]">{myEquipment.main_gut_guage.toFixed(2)} mm</p>
-                                        <p className="tracking-tighter h-[16px] text-[14px] mr-auto">{myEquipment.main_gut_tension} ポンド</p>
+                                        <p className="tracking-tighter h-[12px] text-[10px] mr-auto mb-[4px]">{myEquipment.main_gut_guage.toFixed(2)} mm</p>
+                                        <p className="tracking-tighter h-[12px] text-[10px] mr-auto">{myEquipment.main_gut_tension} ポンド</p>
                                       </div>
                                     </div>
                                   </div>
@@ -141,12 +141,12 @@ const MyEquipmentList = () => {
                                   <div>
                                     <div className="w-[92px] flex flex-col items-center">
                                       {myEquipment.racket.racket_image.file_path &&
-                                        <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-4" />
+                                        <img src={`${myEquipment.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[69px] h-[92px] mb-1" />
                                       }
 
                                       <div className="text-center">
-                                        <p className="h-[16px] text-[14px] mb-4">{myEquipment.racket.maker.name_ja}</p>
-                                        <p className="tracking-tighter break-words min-h-[16px] text-[14px] max-w-[92px] ">{myEquipment.racket.name_ja}</p>
+                                        <p className="h-[10px] text-[10px] mb-2">{myEquipment.racket.maker.name_ja}</p>
+                                        <p className="tracking-tighter break-words min-h-[16px] text-[14px] text-left max-w-[92px] ">{myEquipment.racket.name_ja}</p>
                                       </div>
                                     </div>
                                   </div>
@@ -154,7 +154,7 @@ const MyEquipmentList = () => {
                               </>
                             )}
 
-                            <hr className="w-[320px] border-sub-green mb-2 mx-auto" />
+                            <hr className="w-[320px] border-sub-green mt-auto mb-2 mx-auto" />
 
                             <div className="flex flex-col items-end mr-[24px]">
                               <span className="inline-block h-[16px] text-[14px] mb-2">張った日：{myEquipment.new_gut_date}</span>

--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -46,9 +46,9 @@ const MyEquipmentList = () => {
                 <PrimaryHeading text="Equipments" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
-              <div className="flex justify-center mb-6 md:w-[784px] md:mx-auto md:justify-end">
+              {/* <div className="flex justify-center mb-6 md:w-[784px] md:mx-auto md:justify-end">
                 <button className="text-white text-[14px] max-w-[264px] w-[100%] h-8 rounded  bg-sub-green md:w-[104px]">検索</button>
-              </div>
+              </div> */}
 
               <div className="flex flex-col items-center md:flex-row md:flex-wrap md:w-[784px] md:justify-between md:mx-auto">
                 {myEquipments && (

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -400,13 +400,13 @@ const ReviewList = () => {
                             {/* 単張りのカード */}
                             {review.my_equipment.stringing_way === "single" && (
                               <>
-                                <div className=" flex justify-center mb-8">
+                                <div className=" flex justify-center ">
                                   <div className="mr-10">
                                     <div className="w-[92px] h-[92px] flex justify-center items-center mb-10">
                                       <div className="w-16">
                                         {review.my_equipment.user.file_path
                                           ? <img src={`${review.my_equipment.user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
+                                          : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full border mb-2" />
                                         }
 
                                         <p className="text-[10px] text-center w-full h-[12px] mb-2">{review.my_equipment.user.name}</p>
@@ -454,7 +454,7 @@ const ReviewList = () => {
                                       <div className="w-16">
                                         {review.my_equipment.user.file_path
                                           ? <img src={`${review.my_equipment.user.file_path}`} width="64px" height="64px" alt="ユーザープロフィール画像" className="rounded-full mb-2" />
-                                          : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] md:w-[80px] h-[64px] md:h-[80px] rounded-full border mb-2" />
+                                          : <img src={`${baseImagePath}images/users/defalt_user_image.png`} width="64px" height="64px" alt="ユーザープロフィール画像" className="w-[64px] h-[64px] rounded-full border mb-2" />
                                         }
 
                                         <p className="text-[10px] text-center w-full h-[12px] mb-2">{review.my_equipment.user.name}</p>
@@ -500,7 +500,7 @@ const ReviewList = () => {
 
                                       <div>
                                         <p className="h-[10px] text-[10px] mr-auto mb-2">{review.my_equipment.cross_gut.maker.name_ja}</p>
-                                        <p className="h-8 text-[14px] mr-auto">{review.my_equipment.cross_gut.name_ja}</p>
+                                        <p className="text-[14px] mr-auto">{review.my_equipment.cross_gut.name_ja}</p>
                                       </div>
 
                                       <div>
@@ -513,7 +513,7 @@ const ReviewList = () => {
                               </>
                             )}
 
-                            <hr className="w-[320px] border-sub-green mb-2 mx-auto" />
+                            <hr className="w-[320px] border-sub-green mt-auto mb-2 mx-auto" />
                             <div className="flex justify-end mr-6">
                               <span className="text-[10px] pr-1">自分に合っているか</span>
 


### PR DESCRIPTION
### issue
#155 

### 背景
レビュー一覧画面とマイ装備一覧画面のカードの表示で挿入テキストが長かったときの改行によるレイアウトの崩れを修正する。

### 確認手順
レビュー一覧画面に遷移する
ユーザ画像及び各名称表示テキストの崩れが確認できる
<img width="1440" alt="スクリーンショット 2024-03-19 午前3 22 59" src="https://github.com/ryuichi-works/strii-frontend/assets/58509835/de72e4bd-a688-4559-878e-d141794c2903">

マイ装備一覧画面に遷移する
テキストが長い表示によるレイアウト崩れが確認できる
<img width="1440" alt="スクリーンショット 2024-03-19 午前3 23 28" src="https://github.com/ryuichi-works/strii-frontend/assets/58509835/f73af0a7-0cd1-4a80-9e93-88bcfe8ecc33">

### やったこと

- [ ] レビュー一覧画面のレイアウト崩れの修正
<img width="1440" alt="スクリーンショット 2024-03-19 午前3 49 21" src="https://github.com/ryuichi-works/strii-frontend/assets/58509835/5ce66539-6277-4adb-979a-214fcd7d6f8d">

- [ ] マイ装備一覧画面のレイアウト崩れの修正
<img width="1440" alt="スクリーンショット 2024-03-19 午前3 49 47" src="https://github.com/ryuichi-works/strii-frontend/assets/58509835/21043219-1200-4a87-acbf-59fddffd7556">

- [ ] マイ装備画面のマイ装備検索ボタンをコメントアウト

### 備考
マイ装備画面のマイ装備検索ボタンはバックエンドでまだ検索機能を実装していないためコメントアウトし表示を非表示にしている

レビューお願いします