### PR TITLE
modify:RacketRegisterModalのエラー表示修正とその他修正

### DIFF
--- a/src/components/RacketRegisterModal.tsx
+++ b/src/components/RacketRegisterModal.tsx
@@ -54,8 +54,8 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
   const [inputHeadSize, setInputHeadSize] = useState<number>(100);
   const [mainGutPattern, setMainGutPattern] = useState<string>('16');
   const [crossGutPattern, setCrossGutPattern] = useState<string>('19');
-  const [racketWeight, setRacketWeight] = useState<number>(300);
-  const [balance, setBalance] = useState<number>(320);
+  const [racketWeight, setRacketWeight] = useState<number | null>(null);
+  const [balance, setBalance] = useState<number | null>(null);
   const [agreement, setAgreement] = useState<boolean>(false);
   
   // useImageCropカスタムフックから取得
@@ -75,7 +75,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     onCropComplete,
     showCroppedImage,
   } = useImageCrop();
-  console.log('croppedImage', croppedImage);
+  // console.log('croppedImage', croppedImage);
 
   const {
     imageFileUrl,
@@ -190,6 +190,16 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     setCroppedImage(undefined)
     setCroppedImageUrl(undefined)
     setErrors(initialErrorVals)
+    setInputNameJa('');
+    setInputNameEn('');
+    setRacketMakerId(null);
+    setRacketSeriresId(null);
+    setInputHeadSize(100);
+    setMainGutPattern('16');
+    setCrossGutPattern('19');
+    setRacketWeight(null);
+    setBalance(null);
+    setAgreement(false);
   }
 
   //エラーメッセージ関連
@@ -207,6 +217,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     agreement: string[],
     file: string[],
     title: string[],
+    limit: string[],
   }
 
   const initialErrorVals: Errors = {
@@ -223,6 +234,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     agreement: [],
     file: [],
     title: [],
+    limit: [],
   };
 
   const [errors, setErrors] = useState<Errors>(initialErrorVals);
@@ -297,11 +309,12 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
               <div>
                 {/* カナ名入力 */}
                 <div className="mb-6">
-                  <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット名(カナ)</label>
+                  <label htmlFor="name_ja" className="block mb-1 text-[14px] md:text-[16px] md:mb-2">ラケット名(カナ) <span className="text-[14px] md:text-[16px] text-red-400">※必須</span></label>
                   <input
                     type="text"
                     name="name_ja"
                     onChange={(e) => setInputNameJa(e.target.value)}
+                    value={inputNameJa}
                     className={`border border-gray-300 rounded w-80 md:w-[360px] h-10 p-2 focus:outline-sub-green ${errors.name_ja.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
                   {errors.name_ja.length !== 0 &&
@@ -316,6 +329,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     type="text"
                     name="name_en"
                     onChange={(e) => setInputNameEn(e.target.value)}
+                    value={inputNameEn}
                     className={`border border-gray-300 rounded w-80 md:w-[360px] h-10 p-2 focus:outline-sub-green ${errors.name_en.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
                   {errors.name_en.length !== 0 &&
@@ -325,12 +339,13 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
 
                 {/* メーカー入力 */}
                 <div className=" mb-8">
-                  <label htmlFor="maker" className="block text-[14px] md:text-[16px]">メーカー</label>
+                  <label htmlFor="maker" className="block text-[14px] md:text-[16px]">メーカー<span className="text-[14px] md:text-[16px] text-red-400"> ※必須</span></label>
 
                   <select
                     name="maker"
                     id="maker"
                     onChange={(e) => { onChangeMaker(e) }}
+                    value={racketMakerId ? String(racketMakerId) : '未選択'}
                     className={` border border-gray-300 rounded w-80 md:w-[360px] h-10 p-2 focus:outline-sub-green ${errors.maker_id.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   >
                     <option value="未選択" selected>未選択</option>
@@ -350,6 +365,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     name="series"
                     id="series"
                     onChange={(e) => { onChangeRacketSeries(e) }}
+                    value={racketSeriresId ? String(racketSeriresId) : '未選択'}
                     className={`border border-gray-300 rounded w-80 md:w-[360px] h-10 p-2 focus:outline-sub-green ${errors.series_id.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   >
                     <option value="未選択" selected>未選択</option>
@@ -363,14 +379,14 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
 
                 {/* ヘッドサイズ入力 */}
                 <div className="mb-6">
-                  <label htmlFor="head_size" className="block text-[14px] md:text-[16px]">ヘッドサイズ</label>
+                  <label htmlFor="head_size" className="block text-[14px] md:text-[16px]">ヘッドサイズ<span className="text-[14px] md:text-[16px] text-red-400"> ※必須</span></label>
                   <input
                     type="number"
                     name="head_size"
                     onChange={onChangeHeadSize}
                     min="77"
                     max="150"
-                    defaultValue={inputHeadSize}
+                    value={inputHeadSize}
                     className={`border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green ${errors.head_size.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
                   <span className="ml-4 text-[14px] md:text-[16px]">平方インチ</span>
@@ -385,6 +401,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                   <label htmlFor="gut_pattern" className="block text-[14px] md:text-[16px]">
                     ストリングパターン
                     <span className="text-[12px] md:text-[14px]">（メイン / クロス）</span>
+                    <span className="text-[14px] md:text-[16px] text-red-400"> ※必須</span>
                   </label>
                   <input
                     type="number"
@@ -392,7 +409,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     onChange={(e) => onChangeGutPattern(e, 'main')}
                     min="11"
                     max="24"
-                    defaultValue={mainGutPattern}
+                    value={mainGutPattern}
                     className={`text-center border border-gray-300 rounded w-14 h-10 p-2 focus:outline-sub-green ${errors.pattern.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
                   <span className="mx-2 text-[14px] md:text-[16px]">/</span>
@@ -402,7 +419,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     onChange={(e) => onChangeGutPattern(e, 'cross')}
                     min="11"
                     max="24"
-                    defaultValue={crossGutPattern}
+                    value={crossGutPattern}
                     className={`text-center border border-gray-300 rounded w-14 h-10 p-2 focus:outline-sub-green ${errors.pattern.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
 
@@ -420,7 +437,8 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     onChange={onChangeRacketWeight}
                     min="0"
                     max="500"
-                    defaultValue={racketWeight}
+                    value={racketWeight ? racketWeight : ''}
+                    placeholder="半角数字"
                     className={`border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green ${errors.weight.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
                   <span className="ml-4 md:text-[16px]">g</span>
@@ -439,10 +457,11 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     onChange={onChangeBalance}
                     min="0"
                     max="400"
-                    defaultValue={balance}
-                    className={`border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green${errors.balance.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
+                    value={balance ? balance : ''}
+                    placeholder="半角数字"
+                    className={`border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green ${errors.balance.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
                   />
-                  <span className="ml-4 md:text-[16px]">g</span>
+                  <span className="ml-4 md:text-[16px]">mm</span>
 
                   {errors.balance.length !== 0 &&
                     errors.balance.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
@@ -457,7 +476,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                 <div className="mb-[24px]">
                   {/* ファイル選択 */}
                   <div className="flex flex-col mb-[16px]">
-                    <label htmlFor="gut_image_file" className="text-[14px] mb-1 md:text-[16px] md:mb-2">ラケット画像</label>
+                    <label htmlFor="gut_image_file" className="text-[14px] mb-1 md:text-[16px] md:mb-2">ラケット画像<span className="text-[14px] md:text-[16px] text-red-400"> ※必須</span></label>
                     <input
                       type="file"
                       name="gut_image_file"
@@ -546,6 +565,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                       id="agreement"
                       onChange={(e) => { onChangeAgreement(e) }}
                       disabled={croppedImage ? false : true}
+                      checked={agreement}
                       className="mr-1"
                     />
                     <label htmlFor="agreement" className="md:text-[16px]">はい</label>
@@ -584,6 +604,9 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     }
                     {errors.file.length !== 0 &&
                       errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.limit.length !== 0 &&
+                      errors.limit.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                     }
                   </div>
                 </div>


### PR DESCRIPTION
### issue
#158 

### 背景
ユーザーがラケットを登録する際に１日の回数制限をbackend laravel側で実装したために、回数制限に引っかかったときのエラーメッセージを表示させる。
また、ラケット登録モーダルの微修正を行う

### 確認手順

- [ ] ラケット登録の１日の規定回数以上登録してみる（既定を１０回にしているが多いのでバックエンドで一時的に少ない回数に変更）
- [ ] デベロッパーツールのネットワークタブで限度回数超過エラーが返ってきてるがサイトでエラー表示がないことが確認できる

### やったこと

- [ ] 登録限度回数長が時のエラーの表示
- [ ] 各入力欄の初期値の調整
- [ ] 入力必須の文字を表示させた

### 備考
登録ボタンかに全体のエラー分表示をさせているが、エラー表示コードが多くなってきているので、リファクタリングで短く記載できるかもしれない

レビューお願いします