### PR TITLE
modify:racketのrelease_yearに関する表示の修正

### DIFF
--- a/src/components/RacketRegisterModal.tsx
+++ b/src/components/RacketRegisterModal.tsx
@@ -56,8 +56,9 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
   const [crossGutPattern, setCrossGutPattern] = useState<string>('19');
   const [racketWeight, setRacketWeight] = useState<number | null>(null);
   const [balance, setBalance] = useState<number | null>(null);
+  const [releaseYear, setReleaseYear] = useState<number | null>(null);
   const [agreement, setAgreement] = useState<boolean>(false);
-  
+
   // useImageCropカスタムフックから取得
   const {
     crop,
@@ -167,6 +168,10 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     setBalance(Number(e.target.value));
   }
 
+  const onChangeReleaseYear = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReleaseYear(Number(e.target.value));
+  }
+
   const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
     changeImageFileToLocationUrl(files);
@@ -199,6 +204,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     setCrossGutPattern('19');
     setRacketWeight(null);
     setBalance(null);
+    setReleaseYear(null);
     setAgreement(false);
   }
 
@@ -214,6 +220,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     pattern: string[],
     weight: string[],
     balance: string[],
+    release_year: string[],
     agreement: string[],
     file: string[],
     title: string[],
@@ -231,6 +238,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
     pattern: [],
     weight: [],
     balance: [],
+    release_year: [],
     agreement: [],
     file: [],
     title: [],
@@ -258,6 +266,7 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
       pattern: `${mainGutPattern}/${crossGutPattern}`,
       weight: racketWeight,
       balance: balance,
+      release_year: releaseYear ? releaseYear : null,
 
       // multipart/form-dataの時はstring型になってしまうため変換
       agreement: Number(agreement),
@@ -467,6 +476,26 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     errors.balance.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                   }
                 </div>
+
+                {/* 発売年入力 */}
+                <div className="mb-6">
+                  <label htmlFor="release_year" className="block text-[14px] md:text-[16px]">発売年</label>
+                  <input
+                    type="number"
+                    name="release_year"
+                    onChange={onChangeReleaseYear}
+                    min="1000"
+                    max="2500"
+                    value={releaseYear ? releaseYear : ''}
+                    placeholder="半角数字(20xx)"
+                    className={`border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green ${errors.balance.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
+                  />
+                  <span className="ml-4 md:text-[16px]">年</span>
+
+                  {errors.release_year.length !== 0 &&
+                    errors.release_year.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                  }
+                </div>
               </div>
 
 
@@ -601,6 +630,9 @@ const RacketRegisterModal: React.FC<RacketRegisterModalProps> = ({
                     }
                     {errors.balance.length !== 0 &&
                       errors.balance.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                    {errors.release_year.length !== 0 &&
+                      errors.release_year.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                     }
                     {errors.file.length !== 0 &&
                       errors.file.map((message, i) => <p key={i} className="text-red-400">{message}</p>)

--- a/src/pages/rackets/[id]/edit.tsx
+++ b/src/pages/rackets/[id]/edit.tsx
@@ -38,6 +38,7 @@ const RacketEdit: NextPage = () => {
   const [crossGutPattern, setCrossGutPattern] = useState<string>();
   const [racketWeight, setRacketWeight] = useState<number | null>();
   const [balance, setBalance] = useState<number | null>();
+  const [releaseYear, setReleaseYear] = useState<number | null>(null);
   const [selectedRacketImage, setSelectedRacketImage] = useState<RacketImage>();
 
   //ラケット画像検索関連のstate
@@ -83,6 +84,7 @@ const RacketEdit: NextPage = () => {
         setCrossGutPattern(splitedPatturn[1]);
         if (racket.weight) setRacketWeight(racket.weight);
         if (racket.balance) setBalance(racket.balance);
+        if (racket.release_year) setReleaseYear(racket.release_year);
       })
     }
 
@@ -159,6 +161,10 @@ const RacketEdit: NextPage = () => {
     setBalance(Number(e.target.value));
   }
 
+  const onChangeReleaseYear = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReleaseYear(Number(e.target.value));
+  }
+
   // makerごとのracketシリーズにフィルタリング
   const filterRacketSeriesByMaker = (makerId: number, racketSeries?: RacketSeries[]) => {
 
@@ -191,7 +197,7 @@ const RacketEdit: NextPage = () => {
     pattern: string[],
     weight: string[],
     balance: string[],
-
+    release_year: string[],
   }
 
   const initialErrorVals = {
@@ -204,6 +210,7 @@ const RacketEdit: NextPage = () => {
     pattern: [],
     weight: [],
     balance: [],
+    release_year: [],
   };
 
   const [errors, setErrors] = useState<Errors>(initialErrorVals);
@@ -256,6 +263,7 @@ const RacketEdit: NextPage = () => {
       pattern: (mainGutPattern && crossGutPattern) ? `${mainGutPattern}/${crossGutPattern}` : '',
       weight: racketWeight ? racketWeight : null,
       balance: balance ? balance : null,
+      release_year: releaseYear ? releaseYear : null,
     }
 
     await csrf();
@@ -426,6 +434,25 @@ const RacketEdit: NextPage = () => {
 
                     {errors.balance.length !== 0 &&
                       errors.balance.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
+                    }
+                  </div>
+
+                  {/* 発売年入力 */}
+                  <div className="mb-6">
+                    <label htmlFor="release_year" className="block text-[14px] md:text-[16px]">発売年</label>
+                    <input
+                      type="number"
+                      name="release_year"
+                      onChange={onChangeReleaseYear}
+                      min="1000"
+                      max="2500"
+                      defaultValue={releaseYear ? releaseYear : undefined}
+                      className={`border border-gray-300 rounded w-40 h-10 p-2 focus:outline-sub-green ${errors.balance.length !== 0 ? '!border-red-300 focus:!outline-red-500' : null}`}
+                    />
+                    <span className="ml-4 md:text-[16px]">年</span>
+
+                    {errors.release_year.length !== 0 &&
+                      errors.release_year.map((message, i) => <p key={i} className="text-red-400">{message}</p>)
                     }
                   </div>
 

--- a/src/pages/rackets/[id]/index.tsx
+++ b/src/pages/rackets/[id]/index.tsx
@@ -83,6 +83,7 @@ const RacketShow = () => {
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">重さ</th>
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">バランス</th>
                       <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ストリングパターン</th>
+                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">発売年</th>
                     </tr>
                   </thead>
 
@@ -93,6 +94,7 @@ const RacketShow = () => {
                       <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.weight ? `${racket?.weight}g` : '未登録' }</td>
                       <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.balance ? `${racket?.balance}mm` : '未登録' }</td>
                       <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.pattern !== '' ? racket?.pattern : '未登録' }</td>
+                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.release_year ? racket?.release_year : '未登録' }年</td>
                     </tr>
                   </tbody>
                 </table>

--- a/src/pages/rackets/index.tsx
+++ b/src/pages/rackets/index.tsx
@@ -189,7 +189,12 @@ const RacketList = () => {
                         <div className="w-[100%] max-w-[176px] pt-4 md:max-w-[216px]">
                           <p className="text-[14px] mb-2 pl-2 md:text-[16px]">{firstLetterToUpperCase(racket.maker.name_en)}</p>
                           <p className="text-[16px] text-center mb-2 md:text-[18px]">{racket.name_ja}</p>
-                          <TextUnderBar className="w-[100%] max-w-[176px] md:max-w-[216px]" />
+                          
+                          <TextUnderBar className="w-[100%] max-w-[176px] mb-1 md:max-w-[216px]" />
+
+                          {racket.release_year &&
+                            <p className="text-[10px] text-right mb-2 md:text-[12px]">{racket.release_year}年</p>
+                          }
                         </div>
                       </div>
                     </Link>

--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -60,6 +60,7 @@ export type Racket = {
   pattern: string,
   weight: number | null,
   balance: number | null,
+  release_year: number | null,
   maker: Maker,
   racket_image: RacketImage,
   user: User,


### PR DESCRIPTION
### issue
#160 

### 背景
バックエンド側でracketsテーブルにrelease_yearカラムを追加したことにより、フロントエンド側の表示を調整する必要が生じたため修正する

### 確認手順

- [ ] ラケット登録モーダルを表示させる
- [ ] モーダル内にrelease_yearに関する入力欄がないことが確認できる
- [ ] ラケット詳細ページを表示させる
- [ ] 発売日(release_year)の情報表示がないことが確認できる
- [ ] ラケット更新ページをadminでログインして表示させる
- [ ] 更新フォーム欄にrelease_yearに関する入力欄がないことが確認できる
- [ ] ラケット一覧ページを表示させる
- [ ] 発売年が表示されてないことが確認できる

### やったこと

- [ ] ラケット登録モーダルにrelease_yearに関する入力欄を用意し登録処理を修正
- [ ] ラケット更新ページにrelease_yearに関する入力欄を用意し更新処理を修正
- [ ] ラケット詳細ページに発売年(release_year)の情報を表示
- [ ] ラケット一覧ページのラケット表示カード内に発売年を表示

### 備考
adminのラケット登録画面は現状ラケット登録はユーザーにお願いするがタチになっているので修正していない。今後必要になった時に修正されたし。

レビューお願いします