### PR TITLE
modify:gut詳細画面の情報表示を修正

### DIFF
--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -78,18 +78,18 @@ const Gut = () => {
                       <thead className="w-[100%] max-w-[120px] md:max-w-[720px] md:mb-4">
                         <tr className="flex flex-col items-start border-r border-sub-green w-[100%] max-w-[120px] md:flex-row md:max-w-[720px] md:border-r-0 md:border-b">
                           <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">メーカー</th>
-                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">カラー</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] tracking-tighter md:text-[16px] md:max-w-[180px]">種類</th>
                           <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">ゲージ</th>
-                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] tracking-tighter md:text-[16px] md:max-w-[180px]">ストリングの種類</th>
+                          <th className="font-normal text-[14px] text-center w-[100%] max-w-[120px] min-h-[45px] leading-[45px] p-[0px] md:text-[16px] md:max-w-[180px]">カラー</th>
                         </tr>
                       </thead>
 
                       <tbody className="w-[100%] max-w-[200px] md:max-w-[720px]">
                         <tr className="flex flex-col items-start w-[100%] max-w-[200px] md:flex-row md:max-w-[720px]">
                           <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">{gut?.maker.name_ja}</td>
-                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">black/white</td>
-                          <td className="pl-6 min-h-[45px] text-[12px] leading-[45px] p-[0px] md:text-[12px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">1.20/1.25/1.30/1.25/1.30mm</td>
-                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">ポリエステル</td>
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">{gut?.category}</td>
+                          <td className="pl-6 min-h-[45px] text-[12px] leading-[45px] p-[0px] md:text-[12px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">{gut?.guage}mm</td>
+                          <td className="pl-6 min-h-[45px] text-[14px] leading-[45px] p-[0px] md:text-[16px] md:pl-0 md:w-[100%] md:max-w-[180px] md:text-center">未登録</td>
                         </tr>
                       </tbody>
                     </table>

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -35,6 +35,8 @@ export type Gut = {
   maker_id: number,
   image_id: number,
   need_posting_image: number,
+  guage: string,
+  category: string,
   created_at: string,
   updated_at: string,
   maker: Maker,


### PR DESCRIPTION
### issue
#162 

### 背景
gut詳細画面の情報表示が開発初期の仮のものになっているためdbの値を表示する様に修正する

### 確認手順

- [ ] gut詳細画面に遷移する

- [ ] gut情報が仮の値になっているのが確認できる。コード側で確認するとわかりやすく値がベタ書きになっているのが確認できる

### やったこと

- [ ] gut詳細画面の仮のデータ表示部分をｄｂの値を表示する様に修正
- [ ] 表の表示順を調整

### 備考
カラーについては「未登録」と表示させており、今後ｄｂにカラムを追加して実装する予定であるが、工数などを考慮すると破棄するかもしれない。

レビューお願いします