### PR TITLE
add:各ページのheadタグのmetaタグとtitleタグを設定

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,6 +6,8 @@ export default function Document() {
     <Html lang="en" className='text-[16px] tracking-wide'>
       <Head>
         <Favicon />
+        <meta name="keywords" content="テニス,テニスガット,テニスストリング,テニス　ガット　おすすめ,テニス　ストリング　おすすめ,ガット　レビュー,ストリング　レビュー" />
+        <meta name="description" content="strii(ストリー)はテニスのストリング・ガット情報に特化したレビューサイトです。上達のために自分に本当に合うストリング・ガット、セッティングを見つけましょう。"/>
       </Head>
 
       <body className='overflow-x-hidden'>

--- a/src/pages/admins/[id]/dashboard.tsx
+++ b/src/pages/admins/[id]/dashboard.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import Head from 'next/head';
 import { useContext } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import AuthAdminCheck from "@/components/AuthAdminCheck";
@@ -12,6 +13,10 @@ const UserProfile: NextPage = () => {
       <AuthAdminCheck>
         {isAuthAdmin && (
           <>
+            <Head>
+              <title>管理者 - dashboard</title>
+            </Head>
+
             <h1>管理dashboard</h1>
           </>
         )}

--- a/src/pages/admins/login.tsx
+++ b/src/pages/admins/login.tsx
@@ -4,6 +4,8 @@ import Cookies from "js-cookie";
 import axios from "@/lib/axios";
 import { useContext, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
+
 import { AuthContext } from "@/context/AuthContext";
 
 const UserLogin: NextPage = () => {
@@ -60,6 +62,10 @@ const UserLogin: NextPage = () => {
 
   return (
     <>
+      <Head>
+        <title>管理者 - ログイン</title>
+      </Head>
+
       <div className="container text-gray-600 px-2 sm:px-5 py-5 mx-auto">
 
         <div className="flex flex-col text-center w-full mb-5">

--- a/src/pages/gut_images/register.tsx
+++ b/src/pages/gut_images/register.tsx
@@ -5,6 +5,7 @@ import Cookies from "js-cookie";
 
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -170,6 +171,10 @@ const GutImageRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>ストリング画像提供</title>
+            </Head>
+
             <div className="container mx-auto mb-[48px]">
               <FlashMessage
                 flashMessage={'画像提供受付ました、ご協力ありがとうございます。'}

--- a/src/pages/guts/[id]/edit.tsx
+++ b/src/pages/guts/[id]/edit.tsx
@@ -6,6 +6,7 @@ import axios from "@/lib/axios";
 import Cookies from "js-cookie";
 import React, { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthAdminCheck from "@/components/AuthAdminCheck";
@@ -192,6 +193,9 @@ const GutEdit: NextPage = () => {
       <AuthAdminCheck>
         {isAuthAdmin && (
           <>
+            <Head>
+              <title>ストリング情報編集 - {currentGut ? (`${currentGut.name_ja} (${currentGut.maker.name_ja})`) : ''}</title>
+            </Head>
 
             <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 

--- a/src/pages/guts/[id]/index.tsx
+++ b/src/pages/guts/[id]/index.tsx
@@ -2,6 +2,7 @@ import type { Gut } from "@/pages/reviews";
 import axios from "@/lib/axios";
 import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -48,6 +49,10 @@ const Gut = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>ストリング - {gut ? (`${gut.name_ja} (${gut.maker.name_ja})`) : ''}</title>
+            </Head>
+
             <div className="container md:mx-auto">
               <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="String" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />

--- a/src/pages/guts/index.tsx
+++ b/src/pages/guts/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import axios from "@/lib/axios";
 import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
+import Head from 'next/head';
 
 import AuthCheck from "@/components/AuthCheck";
 import TextUnderBar from "@/components/TextUnderBar";
@@ -112,102 +113,108 @@ const GutList = () => {
     <>
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
-          <div className="container mx-auto">
-            <div className="text-center my-6 md:my-[32px]">
-              <PrimaryHeading text="Strings" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
-            </div>
+          <>
+            <Head>
+              <title>ストリング一覧</title>
+            </Head>
 
-            <div className="flex justify-center mb-[48px] md:justify-end w-[100%] max-w-[768px] mx-auto">
-              <button
-                onClick={openModal}
-                className="text-white text-[14px] w-[264px] h-8 rounded  bg-sub-green md:w-[80px] md:h-[32px] md:hidden"
-              >検索</button>
+            <div className="container mx-auto">
+              <div className="text-center my-6 md:my-[32px]">
+                <PrimaryHeading text="Strings" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
+              </div>
 
-              <div className={'hidden md:block bg-gray-300 w-[100%] max-w-[768px] h-[100px] rounded-lg'}>
-                <div className="flex flex-col items-center justify-center w-[100%] mx-auto max-w-[768px] h-[100%]">
-                  <form action="" onSubmit={searchGuts} className=" flex">
-                    <div className="mb-6 md:mb-0 md:mr-[16px]">
-                      <label htmlFor="name_ja" className="block text-[16px] mb-2 pl-1 h-[18px]">ストリング検索ワード</label>
-                      <input
-                        type="text"
-                        name="name_ja"
-                        defaultValue={inputSearchWord}
-                        onChange={(e) => setInputSearchWord(e.target.value)}
-                        className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
-                      />
-                    </div>
+              <div className="flex justify-center mb-[48px] md:justify-end w-[100%] max-w-[768px] mx-auto">
+                <button
+                  onClick={openModal}
+                  className="text-white text-[14px] w-[264px] h-8 rounded  bg-sub-green md:w-[80px] md:h-[32px] md:hidden"
+                >検索</button>
 
-                    <div className="mb-8 md:mb-0 md:mr-[24px]">
-                      <label htmlFor="maker" className="block text-[16px] mb-2 pl-1  h-[18px]">メーカー</label>
+                <div className={'hidden md:block bg-gray-300 w-[100%] max-w-[768px] h-[100px] rounded-lg'}>
+                  <div className="flex flex-col items-center justify-center w-[100%] mx-auto max-w-[768px] h-[100%]">
+                    <form action="" onSubmit={searchGuts} className=" flex">
+                      <div className="mb-6 md:mb-0 md:mr-[16px]">
+                        <label htmlFor="name_ja" className="block text-[16px] mb-2 pl-1 h-[18px]">ストリング検索ワード</label>
+                        <input
+                          type="text"
+                          name="name_ja"
+                          defaultValue={inputSearchWord}
+                          onChange={(e) => setInputSearchWord(e.target.value)}
+                          className="border border-gray-300 rounded w-80 md:w-[300px] h-10 p-2 focus:outline-sub-green"
+                        />
+                      </div>
 
-                      <select
-                        name="maker"
-                        id="maker"
-                        value={inputSearchMaker ? inputSearchMaker : '未選択'}
-                        onChange={(e) => { onChangeInputSearchMaker(e) }}
-                        className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
-                      >
-                        <option value="未選択" selected>未選択</option>
-                        {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
-                      </select>
-                    </div>
+                      <div className="mb-8 md:mb-0 md:mr-[24px]">
+                        <label htmlFor="maker" className="block text-[16px] mb-2 pl-1  h-[18px]">メーカー</label>
 
-                    <div className="flex justify-end md:justify-start">
-                      <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
-                    </div>
-                  </form>
+                        <select
+                          name="maker"
+                          id="maker"
+                          value={inputSearchMaker ? inputSearchMaker : '未選択'}
+                          onChange={(e) => { onChangeInputSearchMaker(e) }}
+                          className="border border-gray-300 rounded w-80 md:w-[250px] h-10 p-2 focus:outline-sub-green"
+                        >
+                          <option value="未選択" selected>未選択</option>
+                          {makers?.map((maker) => (<option key={maker.id} value={maker.id}>{maker.name_ja}</option>))}
+                        </select>
+                      </div>
+
+                      <div className="flex justify-end md:justify-start">
+                        <button type="submit" className="text-white font-bold text-[14px] w-[160px] h-8 rounded  bg-sub-green md:text-[16px] md:self-end md:h-[40px] md:w-[100px]">検索する</button>
+                      </div>
+                    </form>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            {/* ガットセクション */}
-            <div className="">
-              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
-                {/* ガット */}
-                {guts && guts.map(gut => (
-                  <Link href={`/guts/${gut.id}`} key={gut.id} className="hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
-                    <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
-                      <div className="w-[120px] mr-6">
-                        {gut.gut_image.file_path
-                          ? <img src={`${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                          : <img src={`${baseImagePath}images/guts/defalt_gut_image.png`} alt="ストリング画像" className="w-[120px] h-[120px]" />
-                        }
-                      </div>
+              {/* ガットセクション */}
+              <div className="">
+                <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
+                  {/* ガット */}
+                  {guts && guts.map(gut => (
+                    <Link href={`/guts/${gut.id}`} key={gut.id} className="hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                      <div className="flex justify-center mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {gut.gut_image.file_path
+                            ? <img src={`${gut.gut_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                            : <img src={`${baseImagePath}images/guts/defalt_gut_image.png`} alt="ストリング画像" className="w-[120px] h-[120px]" />
+                          }
+                        </div>
 
-                      <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
-                        <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
-                        <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
-                        <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                        <div className="w-[100%] max-w-[160px] md:max-w-[216px]">
+                          <p className="text-[14px] mb-2 md:text-[16px]">{gut.maker.name_ja}</p>
+                          <p className="text-[16px] mb-2 md:text-[18px]">{gut.name_ja}</p>
+                          <TextUnderBar className="w-[100%] max-w-[160px] md:max-w-[216px]" />
+                        </div>
                       </div>
-                    </div>
-                  </Link>
-                ))}
+                    </Link>
+                  ))}
+                </div>
               </div>
+
+              {/* 検索モーダル */}
+              <GutSearchModal
+                modalVisibility={gutSearchModalVisibility}
+                setModalVisibility={setGutSearchModalVisibility}
+                makers={makers}
+                showingResult={false}
+                searchedGuts={guts}
+                setSearchedGuts={setGuts}
+                zIndexClassName={'z-50'}
+                setGutsPaginator={setGutsPaginator}
+                inputSearchWord={inputSearchWord}
+                setInputSearchWord={setInputSearchWord}
+                inputSearchMaker={inputSearchMaker}
+                setInputSearchMaker={setInputSearchMaker}
+              />
+
+              {/* ページネーション */}
+              <Pagination
+                paginator={gutsPaginator}
+                paginate={getGutsList}
+                className="mt-[32px] md:mt-[48px]"
+              />
             </div>
-
-            {/* 検索モーダル */}
-            <GutSearchModal
-              modalVisibility={gutSearchModalVisibility}
-              setModalVisibility={setGutSearchModalVisibility}
-              makers={makers}
-              showingResult={false}
-              searchedGuts={guts}
-              setSearchedGuts={setGuts}
-              zIndexClassName={'z-50'}
-              setGutsPaginator={setGutsPaginator}
-              inputSearchWord={inputSearchWord}
-              setInputSearchWord={setInputSearchWord}
-              inputSearchMaker={inputSearchMaker}
-              setInputSearchMaker={setInputSearchMaker}
-            />
-
-            {/* ページネーション */}
-            <Pagination
-              paginator={gutsPaginator}
-              paginate={getGutsList}
-              className="mt-[32px] md:mt-[48px]"
-            />
-          </div>
+          </>
         )}
       </AuthCheck>
     </>

--- a/src/pages/guts/register.tsx
+++ b/src/pages/guts/register.tsx
@@ -8,6 +8,7 @@ import axios from "@/lib/axios";
 import Cookies from "js-cookie";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import React, { useContext, useEffect, useState } from "react";
 import { IoClose } from "react-icons/io5";
 
@@ -173,6 +174,9 @@ const GutRegister: NextPage = () => {
       <AuthAdminCheck>
         {isAuthAdmin && (
           <>
+            <Head>
+              <title>ストリング登録</title>
+            </Head>
 
             <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import { Inter } from 'next/font/google'
 import Link from 'next/link';
+import Head from 'next/head'
 import SubHeading from '@/components/SubHeading';
 import TextUnderBar from '@/components/TextUnderBar';
 import HeroPcSize from '../../public/hero_pc_size.png';
@@ -11,6 +12,9 @@ const inter = Inter({ subsets: ['latin'] })
 export default function Home() {
   return (
     <>
+      <Head>
+        <title>strii(ストリー) - テニスのストリング・ガット、レビューサイト</title>
+      </Head>
       <div className="mx-auto">
         {/* hero section */}
         <section className='container mx-auto h-[480px] sm:h-[358px] md:h-[430px] xl:h-[571px]'>

--- a/src/pages/my_equipments/[id]/edit.tsx
+++ b/src/pages/my_equipments/[id]/edit.tsx
@@ -8,6 +8,7 @@ import Cookies from "js-cookie";
 
 import React, { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -296,6 +297,18 @@ const MyEquipmentEdit: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>
+                マイ装備編集 - {currentMyEquipment ? `${currentMyEquipment?.main_gut.name_ja}` : ''}
+                {
+                  currentMyEquipment?.stringing_way === 'hybrid'
+                    ? `/${currentMyEquipment.cross_gut.name_ja}`
+                    : ''
+                }
+                {currentMyEquipment ? `/${currentMyEquipment.racket.name_ja}` : ''}
+              </title>
+            </Head>
+
             <div className="container mx-auto">
               <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />

--- a/src/pages/my_equipments/[id]/my_equipment.tsx
+++ b/src/pages/my_equipments/[id]/my_equipment.tsx
@@ -2,6 +2,7 @@ import type { MyEquipment } from "@/pages/reviews";
 import React, { useContext, useEffect, useState } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import axios from "@/lib/axios";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -39,130 +40,143 @@ const MyEquipment = () => {
     <>
       <AuthCheck>
         {isAuth && (
-          <div className="container mb-8 mx-auto">
-            <div className=" w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-              <div className="text-center my-6 md:mb-[32px]">
-                <PrimaryHeading text="Equipment" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
-              </div>
-
-              <div className="md:flex md:flex-col md:max-h-[700px] md:flex-wrap">
-                {/* ガットセクション */}
-                <div className="flex flex-col items-center mb-8 md:w-[100%] md:max-w-[360px]">
-                  <div className="w-[100%] max-w-[300px] mb-4 md:max-w-[360px]">
-                    {myEquipment?.stringing_way === 'hybrid'
-                      ? <SubHeading text='ストリング（ハイブリッド張り）' className="text-[16px] w-[100%] max-w-[300px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
-                      : <SubHeading text='ストリング（単張り）' className="text-[16px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
-                    }
-                    <TextUnderBar className="w-[100%] max-w-[300px] md:max-w-[360px]" />
-                  </div>
-
-                  {/* ガット */}
-                  <div className="flex justify-center w-[100%] max-w-[300px] md:flex-col md:max-w-[360px]">
-                    {/* メインガット */}
-                    <div className="md:flex md:mb-4">
-                      <div className="md:mr-[24px]">
-                        <p className="text-[14px] md:text-[16px]">メイン</p>
-                        {myEquipment?.main_gut.gut_image.file_path
-                          ? <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
-                          : <div className="w-[120px] h-[120px] border"></div>
-                        }
-                      </div>
-
-                      <div className="md:w-[185px] md:mt-[24px]">
-                        <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment?.main_gut.maker.name_ja}</p>
-                        <p className="text-[14px] mb-2 md:text-[18px] md:text-center md:h-[20px]">{myEquipment?.main_gut.name_ja}</p>
-                        <TextUnderBar className="w-[100%] max-w-[92px] mb-2 md:max-w-[185px]" />
-
-                        {myEquipment?.stringing_way === 'hybrid'
-                          ? (
-                            <>
-                              <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment.main_gut_guage.toFixed(2)}ｍｍ</p>
-                              <p className="text-[14px] md:text-[16px] md:h-[18px]">{myEquipment?.cross_gut_tension}ポンド</p>
-                            </>
-                          ) : (
-                            <>
-                              <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment?.main_gut_guage.toFixed(2)}/{myEquipment?.cross_gut_guage.toFixed(2)}ｍｍ</p>
-                              <p className="text-[14px] md:text-[16px] md:h-[18px]">{myEquipment?.main_gut_tension}/{myEquipment?.cross_gut_tension}ポンド</p>
-                            </>
-                          )
-                        }
-                      </div>
-                    </div>
-
-                    {/* クロスガット */}
-                    {myEquipment?.stringing_way === 'hybrid' && (
-                      <>
-                        <div className="ml-[48px] md:ml-0 md:flex">
-                          <div className="md:mr-[24px]">
-                            <p className="text-[14px] md:text-[16px]">クロス</p>
-                            {myEquipment?.cross_gut.gut_image.file_path
-                              ? <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
-                              : <div className="w-[120px] h-[120px] border"></div>
-                            }
-                          </div>
-
-                          <div className="md:w-[185px] md:mt-[24px]">
-                            <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment?.cross_gut.maker.name_ja}</p>
-                            <p className="text-[14px] mb-2 md:text-[18px] md:text-center md:h-[20px]">{myEquipment?.cross_gut.name_ja}</p>
-                            <TextUnderBar className="w-[100%] max-w-[92px] mb-2 md:max-w-[185px]" />
-                            <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment.cross_gut_guage.toFixed(2)}ｍｍ</p>
-                            <p className="text-[14px] md:text-[16px] md:h-[18px]">{myEquipment?.cross_gut_tension}ポンド</p>
-                          </div>
-                        </div>
-                      </>
-                    )}
-                  </div>
+          <>
+            <Head>
+              <title>
+                マイ装備 - {myEquipment ? `${myEquipment?.main_gut.name_ja}` : ''}
+                  {
+                    myEquipment?.stringing_way === 'hybrid'
+                      ? `/${myEquipment.cross_gut.name_ja}`
+                      : ''
+                  }
+                  {myEquipment ? `/${myEquipment.racket.name_ja}` : ''}
+              </title>
+            </Head>
+            <div className="container mb-8 mx-auto">
+              <div className=" w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                <div className="text-center my-6 md:mb-[32px]">
+                  <PrimaryHeading text="Equipment" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
                 </div>
 
-                {/* ラケットセクション */}
-                <div className="flex flex-col items-center mb-8 md:w-[100%] md:max-w-[360px]">
-                  <div className="w-[100%] max-w-[300px] mb-4 md:max-w-[360px]">
-                    <SubHeading text='ラケット' className="text-[16px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
-                    <TextUnderBar className="w-[100%] max-w-[300px] md:max-w-[360px]" />
-                  </div>
-
-                  {/* ラケット */}
-                  <div className="flex justify-center md:justify-start">
-                    <div className="mr-[24px]">
-                      {myEquipment?.racket.racket_image.file_path
-                        ? <img src={`${myEquipment?.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[92px] h-[132px] mb-1 md:w-[120px] md:h-[160px] md:mb-0" />
-                        : <div className="w-[120px] h-[160px] border"></div>
+                <div className="md:flex md:flex-col md:max-h-[700px] md:flex-wrap">
+                  {/* ガットセクション */}
+                  <div className="flex flex-col items-center mb-8 md:w-[100%] md:max-w-[360px]">
+                    <div className="w-[100%] max-w-[300px] mb-4 md:max-w-[360px]">
+                      {myEquipment?.stringing_way === 'hybrid'
+                        ? <SubHeading text='ストリング（ハイブリッド張り）' className="text-[16px] w-[100%] max-w-[300px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
+                        : <SubHeading text='ストリング（単張り）' className="text-[16px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
                       }
+                      <TextUnderBar className="w-[100%] max-w-[300px] md:max-w-[360px]" />
                     </div>
 
-                    <div className="md:w-[185px]">
-                      <p className="text-[14px] mb-2 md:text-[16px]">{myEquipment?.racket.maker.name_ja}</p>
-                      <p className="text-[16px] mb-2 md:text-[18px] md:text-center">{myEquipment?.racket.name_ja}</p>
-                      <TextUnderBar className="w-[100%] max-w-[116px] md:max-w-[185px]" />
+                    {/* ガット */}
+                    <div className="flex justify-center w-[100%] max-w-[300px] md:flex-col md:max-w-[360px]">
+                      {/* メインガット */}
+                      <div className="md:flex md:mb-4">
+                        <div className="md:mr-[24px]">
+                          <p className="text-[14px] md:text-[16px]">メイン</p>
+                          {myEquipment?.main_gut.gut_image.file_path
+                            ? <img src={`${myEquipment.main_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
+                            : <div className="w-[120px] h-[120px] border"></div>
+                          }
+                        </div>
+
+                        <div className="md:w-[185px] md:mt-[24px]">
+                          <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment?.main_gut.maker.name_ja}</p>
+                          <p className="text-[14px] mb-2 md:text-[18px] md:text-center md:h-[20px]">{myEquipment?.main_gut.name_ja}</p>
+                          <TextUnderBar className="w-[100%] max-w-[92px] mb-2 md:max-w-[185px]" />
+
+                          {myEquipment?.stringing_way === 'hybrid'
+                            ? (
+                              <>
+                                <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment.main_gut_guage.toFixed(2)}ｍｍ</p>
+                                <p className="text-[14px] md:text-[16px] md:h-[18px]">{myEquipment?.cross_gut_tension}ポンド</p>
+                              </>
+                            ) : (
+                              <>
+                                <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment?.main_gut_guage.toFixed(2)}/{myEquipment?.cross_gut_guage.toFixed(2)}ｍｍ</p>
+                                <p className="text-[14px] md:text-[16px] md:h-[18px]">{myEquipment?.main_gut_tension}/{myEquipment?.cross_gut_tension}ポンド</p>
+                              </>
+                            )
+                          }
+                        </div>
+                      </div>
+
+                      {/* クロスガット */}
+                      {myEquipment?.stringing_way === 'hybrid' && (
+                        <>
+                          <div className="ml-[48px] md:ml-0 md:flex">
+                            <div className="md:mr-[24px]">
+                              <p className="text-[14px] md:text-[16px]">クロス</p>
+                              {myEquipment?.cross_gut.gut_image.file_path
+                                ? <img src={`${myEquipment.cross_gut.gut_image.file_path}`} alt="ユーザープロフィール画像" className="w-[92px] h-[92px] mb-1 md:w-[120px] md:h-[120px] md:mb-0" />
+                                : <div className="w-[120px] h-[120px] border"></div>
+                              }
+                            </div>
+
+                            <div className="md:w-[185px] md:mt-[24px]">
+                              <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment?.cross_gut.maker.name_ja}</p>
+                              <p className="text-[14px] mb-2 md:text-[18px] md:text-center md:h-[20px]">{myEquipment?.cross_gut.name_ja}</p>
+                              <TextUnderBar className="w-[100%] max-w-[92px] mb-2 md:max-w-[185px]" />
+                              <p className="text-[14px] mb-2 md:text-[16px] md:h-[18px]">{myEquipment.cross_gut_guage.toFixed(2)}ｍｍ</p>
+                              <p className="text-[14px] md:text-[16px] md:h-[18px]">{myEquipment?.cross_gut_tension}ポンド</p>
+                            </div>
+                          </div>
+                        </>
+                      )}
                     </div>
                   </div>
-                </div>
 
-                <TextUnderBar className="w-[100%] max-w-[300px] mb-4 mx-auto md:hidden" />
+                  {/* ラケットセクション */}
+                  <div className="flex flex-col items-center mb-8 md:w-[100%] md:max-w-[360px]">
+                    <div className="w-[100%] max-w-[300px] mb-4 md:max-w-[360px]">
+                      <SubHeading text='ラケット' className="text-[16px] ml-[8px] mb-1 md:text-[18px] md:mb-2" />
+                      <TextUnderBar className="w-[100%] max-w-[300px] md:max-w-[360px]" />
+                    </div>
 
-                {/* ストリング日時セクション */}
-                <div className="flex flex-col items-center mb-8 md:mt-[35px]">
-                  <div className="w-[100%] max-w-[300px] border border-dashed border-black rounded-lg px-2 py-4 md:max-w-[360px] md:min-h-[240px] md:flex md:flex-col md:justify-center md:items-start md:pl-6">
-                    <p className="text-[14px] text-right mb-2 md:test-[16px] md:mb-10">張った日：{myEquipment?.new_gut_date}</p>
-                    <p className="tracking-tight text-[14px] text-right md:test-[16px] ">ストリング張り替え・切れた日：{myEquipment?.change_gut_date}</p>
+                    {/* ラケット */}
+                    <div className="flex justify-center md:justify-start">
+                      <div className="mr-[24px]">
+                        {myEquipment?.racket.racket_image.file_path
+                          ? <img src={`${myEquipment?.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[92px] h-[132px] mb-1 md:w-[120px] md:h-[160px] md:mb-0" />
+                          : <div className="w-[120px] h-[160px] border"></div>
+                        }
+                      </div>
+
+                      <div className="md:w-[185px]">
+                        <p className="text-[14px] mb-2 md:text-[16px]">{myEquipment?.racket.maker.name_ja}</p>
+                        <p className="text-[16px] mb-2 md:text-[18px] md:text-center">{myEquipment?.racket.name_ja}</p>
+                        <TextUnderBar className="w-[100%] max-w-[116px] md:max-w-[185px]" />
+                      </div>
+                    </div>
                   </div>
-                </div>
 
-                {/* コメントセクション */}
+                  <TextUnderBar className="w-[100%] max-w-[300px] mb-4 mx-auto md:hidden" />
+
+                  {/* ストリング日時セクション */}
+                  <div className="flex flex-col items-center mb-8 md:mt-[35px]">
+                    <div className="w-[100%] max-w-[300px] border border-dashed border-black rounded-lg px-2 py-4 md:max-w-[360px] md:min-h-[240px] md:flex md:flex-col md:justify-center md:items-start md:pl-6">
+                      <p className="text-[14px] text-right mb-2 md:test-[16px] md:mb-10">張った日：{myEquipment?.new_gut_date}</p>
+                      <p className="tracking-tight text-[14px] text-right md:test-[16px] ">ストリング張り替え・切れた日：{myEquipment?.change_gut_date}</p>
+                    </div>
+                  </div>
+
+                  {/* コメントセクション */}
                   <div className="flex flex-col items-center">
                     <p className="text-[14px] text-left w-[100%] max-w-[300px] md:text-[16px] md:mb-2 md:max-w-[360px]">コメント</p>
                     <p className="w-[100%] max-w-[300px] min-h-[160px] border p-2 md:max-w-[360px] md:min-h-[267px]" >{myEquipment?.comment}</p>
                   </div>
-              </div>
+                </div>
 
-              <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-[24px] md:justify-end md:max-w-[768px]">
-                <Link
-                  href={`/my_equipments/${myEquipmentId}/edit`}
-                  className="inline-block  text-[14px] text-white text-center leading-[32px] font-bold w-[80px] h-[32px] rounded  bg-sub-green md:text-[16px] md:w-[100px]"
-                >編集</Link>
+                <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-[24px] md:justify-end md:max-w-[768px]">
+                  <Link
+                    href={`/my_equipments/${myEquipmentId}/edit`}
+                    className="inline-block  text-[14px] text-white text-center leading-[32px] font-bold w-[80px] h-[32px] rounded  bg-sub-green md:text-[16px] md:w-[100px]"
+                  >編集</Link>
+                </div>
               </div>
             </div>
-          </div>
+          </>
         )}
       </AuthCheck>
     </>

--- a/src/pages/my_equipments/index.tsx
+++ b/src/pages/my_equipments/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import axios from "@/lib/axios";
 import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
+import Head from 'next/head';
 import AuthCheck from "@/components/AuthCheck";
 import PrimaryHeading from "@/components/PrimaryHeading";
 import Pagination, { Paginator } from "@/components/Pagination";
@@ -41,6 +42,10 @@ const MyEquipmentList = () => {
       <AuthCheck>
         {isAuth && (
           <>
+            <Head>
+              <title>マイ装備一覧</title>
+            </Head>
+
             <div className="container mx-auto px-2">
               <div className="text-center my-6 md:my-[32px]">
                 <PrimaryHeading text="Equipments" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />

--- a/src/pages/my_equipments/register.tsx
+++ b/src/pages/my_equipments/register.tsx
@@ -7,6 +7,7 @@ import Cookies from "js-cookie";
 
 import React, { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -294,6 +295,10 @@ const MyEquipmentRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>マイ装備登録</title>
+            </Head>
+
             <div className="container mx-auto">
               <div className="text-center my-6 md:mb-[32px]">
                 <PrimaryHeading text="マイ装備追加" className="text-[18px] h-[20px] md:text-[20px] md:h-[22px]" />

--- a/src/pages/racket_images/register.tsx
+++ b/src/pages/racket_images/register.tsx
@@ -5,6 +5,7 @@ import Cookies from "js-cookie";
 
 import { useContext, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -172,6 +173,10 @@ const GutImageRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>ラケット画像提供</title>
+            </Head>
+
             <div className="container mx-auto mb-[48px]">
               <FlashMessage
                 flashMessage={'画像提供受付ました、ご協力ありがとうございます。'}

--- a/src/pages/rackets/[id]/edit.tsx
+++ b/src/pages/rackets/[id]/edit.tsx
@@ -7,6 +7,7 @@ import axios from "@/lib/axios";
 import Cookies from "js-cookie";
 import React, { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthAdminCheck from "@/components/AuthAdminCheck";
@@ -290,6 +291,9 @@ const RacketEdit: NextPage = () => {
       <AuthAdminCheck>
         {isAuthAdmin && (
           <>
+            <Head>
+              <title>ラケット情報編集 - {currentRacket ? (`${currentRacket.name_ja} (${currentRacket.maker.name_ja})`) : ''}</title>
+            </Head>
 
             <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 

--- a/src/pages/rackets/[id]/index.tsx
+++ b/src/pages/rackets/[id]/index.tsx
@@ -2,6 +2,7 @@ import type { Racket } from "@/pages/users/[id]/profile";
 import axios from "@/lib/axios";
 import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import Link from "next/link";
@@ -49,92 +50,98 @@ const RacketShow = () => {
     <>
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
-          <div className="container mx-auto">
-            <div className="text-center my-6  md:my-[32px]">
-              <PrimaryHeading text="Racket" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
-            </div>
+          <>
+            <Head>
+              <title>ラケット - {racket ? (`${racket.name_ja} (${racket.maker.name_ja})`) : ''}</title>
+            </Head>
 
-            {/* ラケットセクション */}
-            <div className="w-[100%] max-w-[320px] mx-auto mb-8 md:max-w-[400px] md:mb-[64px]">
-              <div className="flex md:w-[100%] md:max-w-[400px]">
-                <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
-                  {racket?.racket_image.file_path
-                    ? <img src={`${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px] md:w-[160px] md:h-[200px]" />
-                    : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                  }
-                </div>
-
-                <div className="w-[100%] max-w-[176px] pt-4 md:max-w-[208px]">
-                  <p className="text-[14px] mb-2 pl-2 md:text-[16px]">{racket && firstLetterToUpperCase(racket.maker.name_en)}</p>
-                  <p className="text-[16px] text-center mb-2 md:text-[18px]">{racket?.name_ja}</p>
-                  <TextUnderBar className="w-[100%] max-w-[176px] md:max-w-[208px]" />
-                </div>
-              </div>
-            </div>
-
-            {/* ラケット情報セクション */}
-            <div className="mb-[64px] md:mb-[128px]">
-              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
-                <table className="flex justify-center w-[100%] max-w-[320px] md:max-w-[768px] ">
-                  <thead className="w-[100%] max-w-[160px] md:max-w-[384px]">
-                    <tr className="flex flex-col text-left ">
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">メーカー</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ヘッドサイズ</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">重さ</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">バランス</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ストリングパターン</th>
-                      <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">発売年</th>
-                    </tr>
-                  </thead>
-
-                  <tbody className="w-[100%] max-w-[320px] md:max-w-[384px]">
-                    <tr className="flex flex-col text-left">
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.maker.name_ja}</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.head_size}平方インチ</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.weight ? `${racket?.weight}g` : '未登録' }</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.balance ? `${racket?.balance}mm` : '未登録' }</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.pattern !== '' ? racket?.pattern : '未登録' }</td>
-                      <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.release_year ? racket?.release_year : '未登録' }年</td>
-                    </tr>
-                  </tbody>
-                </table>
+            <div className="container mx-auto">
+              <div className="text-center my-6  md:my-[32px]">
+                <PrimaryHeading text="Racket" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
               </div>
 
-              {isAuthAdmin && (
-                <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-6 md:max-w-[720px] md:justify-end">
-                  <Link href={`/rackets/${racket?.id}/edit`}>
-                    <button type="button" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">更新</button>
-                  </Link>
-                </div>
-              )}
-            </div>
+              {/* ラケットセクション */}
+              <div className="w-[100%] max-w-[320px] mx-auto mb-8 md:max-w-[400px] md:mb-[64px]">
+                <div className="flex md:w-[100%] md:max-w-[400px]">
+                  <div className="w-[120px] mr-6 md:w-[160px] md:mr-8">
+                    {racket?.racket_image.file_path
+                      ? <img src={`${racket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px] md:w-[160px] md:h-[200px]" />
+                      : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                    }
+                  </div>
 
-            {/* otherラケットセクション */}
-            <div className="">
-              <p className="text-[14px] w-[100%] max-w-[320px] mx-auto mb-2 md:max-w-[768px] md:mb-[16px]">その他のラケット</p>
-              <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
-                {/* ラケット */}
-                {otherRackets && otherRackets.map(otherRacket => (
-                  <Link href={`/rackets/${otherRacket.id}`} key={otherRacket.id} onClick={() => setId(`${otherRacket.id}`)} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
-                    <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
-                      <div className="w-[120px] mr-6">
-                        {otherRacket.racket_image.file_path
-                          ? <img src={`${otherRacket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
-                          : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
-                        }
+                  <div className="w-[100%] max-w-[176px] pt-4 md:max-w-[208px]">
+                    <p className="text-[14px] mb-2 pl-2 md:text-[16px]">{racket && firstLetterToUpperCase(racket.maker.name_en)}</p>
+                    <p className="text-[16px] text-center mb-2 md:text-[18px]">{racket?.name_ja}</p>
+                    <TextUnderBar className="w-[100%] max-w-[176px] md:max-w-[208px]" />
+                  </div>
+                </div>
+              </div>
+
+              {/* ラケット情報セクション */}
+              <div className="mb-[64px] md:mb-[128px]">
+                <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px]">
+                  <table className="flex justify-center w-[100%] max-w-[320px] md:max-w-[768px] ">
+                    <thead className="w-[100%] max-w-[160px] md:max-w-[384px]">
+                      <tr className="flex flex-col text-left ">
+                        <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">メーカー</th>
+                        <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ヘッドサイズ</th>
+                        <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">重さ</th>
+                        <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">バランス</th>
+                        <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">ストリングパターン</th>
+                        <th className="font-normal text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px] md:pl-6">発売年</th>
+                      </tr>
+                    </thead>
+
+                    <tbody className="w-[100%] max-w-[320px] md:max-w-[384px]">
+                      <tr className="flex flex-col text-left">
+                        <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.maker.name_ja}</td>
+                        <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.head_size}平方インチ</td>
+                        <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.weight ? `${racket?.weight}g` : '未登録'}</td>
+                        <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.balance ? `${racket?.balance}mm` : '未登録'}</td>
+                        <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.pattern !== '' ? racket?.pattern : '未登録'}</td>
+                        <td className="text-[14px] h-[32px] leading-[32px] p-[0px] pl-1 border-t border-sub-green md:text-[16px] md:h-[50px] md:leading-[50px]">{racket?.release_year ? racket?.release_year : '未登録'}年</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                {isAuthAdmin && (
+                  <div className="flex justify-center w-[100%] max-w-[320px] mx-auto mt-6 md:max-w-[720px] md:justify-end">
+                    <Link href={`/rackets/${racket?.id}/edit`}>
+                      <button type="button" className="text-white font-bold text-[14px] w-[200px] h-8 rounded  bg-sub-green">更新</button>
+                    </Link>
+                  </div>
+                )}
+              </div>
+
+              {/* otherラケットセクション */}
+              <div className="">
+                <p className="text-[14px] w-[100%] max-w-[320px] mx-auto mb-2 md:max-w-[768px] md:mb-[16px]">その他のラケット</p>
+                <div className="w-[100%] max-w-[320px] mx-auto md:max-w-[768px] md:flex md:flex-wrap md:justify-between ">
+                  {/* ラケット */}
+                  {otherRackets && otherRackets.map(otherRacket => (
+                    <Link href={`/rackets/${otherRacket.id}`} key={otherRacket.id} onClick={() => setId(`${otherRacket.id}`)} className="block hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                      <div className="flex  mb-6 hover:opacity-80 hover:cursor-pointer md:w-[100%] md:max-w-[360px]">
+                        <div className="w-[120px] mr-6">
+                          {otherRacket.racket_image.file_path
+                            ? <img src={`${otherRacket.racket_image.file_path}`} alt="ストリング画像" className="w-[120px] h-[160px]" />
+                            : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
+                          }
+                        </div>
+
+                        <div className="w-[100%] max-w-[176px] pt-4 md:max-w-[216px]">
+                          <p className="text-[14px] mb-2 pl-2 md:text-[16px]">{firstLetterToUpperCase(otherRacket.maker.name_en)}</p>
+                          <p className="text-[16px] text-center mb-2 md:text-[18px]">{otherRacket.name_ja}</p>
+                          <TextUnderBar className="w-[100%] max-w-[176px] md:max-w-[216px]" />
+                        </div>
                       </div>
-
-                      <div className="w-[100%] max-w-[176px] pt-4 md:max-w-[216px]">
-                        <p className="text-[14px] mb-2 pl-2 md:text-[16px]">{firstLetterToUpperCase(otherRacket.maker.name_en)}</p>
-                        <p className="text-[16px] text-center mb-2 md:text-[18px]">{otherRacket.name_ja}</p>
-                        <TextUnderBar className="w-[100%] max-w-[176px] md:max-w-[216px]" />
-                      </div>
-                    </div>
-                  </Link>
-                ))}
+                    </Link>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
+          </>
         )}
       </AuthCheck>
     </>

--- a/src/pages/rackets/index.tsx
+++ b/src/pages/rackets/index.tsx
@@ -8,6 +8,7 @@ import { AuthContext } from "@/context/AuthContext";
 import { RacketContext } from "@/context/RacketContext";
 import { usePathHistory } from "@/context/HistoryContext";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 
 import Link from "next/link";
 import AuthCheck from "@/components/AuthCheck";
@@ -110,6 +111,10 @@ const RacketList = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>ラケット一覧</title>
+            </Head>
+
             <div className="container mx-auto mt-[24px] md:mt-[32px]">
               <div className="text-center mb-6 md:mb-[32px]">
                 <PrimaryHeading text="Rackets" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />

--- a/src/pages/rackets/register.tsx
+++ b/src/pages/rackets/register.tsx
@@ -6,6 +6,7 @@ import { AuthContext } from "@/context/AuthContext";
 import axios from "@/lib/axios";
 import Cookies from "js-cookie";
 import type { NextPage } from "next";
+import Head from 'next/head';
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
 import { IoClose } from "react-icons/io5";
@@ -168,6 +169,9 @@ const RacketRegister: NextPage = () => {
       <AuthAdminCheck>
         {isAuthAdmin && (
           <>
+            <Head>
+              <title>ラケット登録</title>
+            </Head>
 
             <div className="container mx-auto mb-8 w-screen overflow-y-auto">
 

--- a/src/pages/reviews/[id]/edit.tsx
+++ b/src/pages/reviews/[id]/edit.tsx
@@ -7,6 +7,7 @@ import Cookies from "js-cookie";
 
 import React, { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -340,6 +341,15 @@ const GutReviewEdit: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>
+                レビュー編集 - {review ? `${review?.my_equipment.main_gut.name_ja}(${review?.my_equipment.main_gut.maker.name_en})` : ''}
+                {review?.my_equipment.stringing_way === 'hybrid'
+                  ? `/${review?.my_equipment.cross_gut.name_ja}(${review?.my_equipment.cross_gut.maker.name_en})`
+                  : ''}
+              </title>
+            </Head>
+
             <div className="container mx-auto mb-6">
               <div className="text-center my-6 md:mb-[32px]">
                 <PrimaryHeading text="Post Review" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />

--- a/src/pages/reviews/[id]/review.tsx
+++ b/src/pages/reviews/[id]/review.tsx
@@ -6,6 +6,7 @@ import axios from "@/lib/axios";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
 import Link from "next/link";
+import Head from 'next/head';
 
 const Review = () => {
   const router = useRouter();
@@ -36,6 +37,15 @@ const Review = () => {
       <AuthCheck>
         {isAuth && (
           <>
+            <Head>
+              <title>
+                レビュー - {review ? `${review?.my_equipment.main_gut.name_ja}(${review?.my_equipment.main_gut.maker.name_en})` : ''}
+                {review?.my_equipment.stringing_way === 'hybrid'
+                  ? `/${review?.my_equipment.cross_gut.name_ja}(${review?.my_equipment.cross_gut.maker.name_en})`
+                  : ''}
+              </title>
+            </Head>
+
             <div className="container mx-auto">
               <h1 className="text-center my-[24px] italic md:my-[32px] md:text-[24px]">Review</h1>
               <div className="flex flex-col items-center flex-wrap">
@@ -134,11 +144,11 @@ const Review = () => {
                     <div className="flex justify-end mb-2">
                       <span className="text-[14px] h-[16px] leading-[16px] pr-1 md:text-[16px] md:h-[18px] md:leading-[18px]">自分に合っているか</span>
                       {review && (
-                          <BarGraph
-                            evaluationVal={review.match_rate as EvaluationVal}
-                            areaSize="md"
-                            graphHeight="h-[16px] md:h-[18px]"
-                          />
+                        <BarGraph
+                          evaluationVal={review.match_rate as EvaluationVal}
+                          areaSize="md"
+                          graphHeight="h-[16px] md:h-[18px]"
+                        />
                       )}
                       <span className="inline-block border-r-2 border-sub-green ml-2 mr-1"></span>
                       <span className="inline-block text-[14px] text-center h-[16px] w-6 leading-[16px] md:text-[16px] md:h-[18px] md:leading-[18px]">{review?.match_rate}</span>
@@ -147,11 +157,11 @@ const Review = () => {
                     <div className="flex justify-end mb-2">
                       <span className="text-[14px] h-[16px] leading-[16px] pr-1 md:text-[16px] md:h-[18px] md:leading-[18px]">切れにくさ</span>
                       {review && (
-                          <BarGraph
-                            evaluationVal={review.pysical_durability as EvaluationVal}
-                            areaSize="md"
-                            graphHeight="h-[16px] md:h-[18px]"
-                          />
+                        <BarGraph
+                          evaluationVal={review.pysical_durability as EvaluationVal}
+                          areaSize="md"
+                          graphHeight="h-[16px] md:h-[18px]"
+                        />
                       )}
                       <span className="inline-block border-r-2 border-sub-green ml-2 mr-1"></span>
                       <span className="inline-block text-[14px] text-center h-[16px] w-6 leading-[16px] md:text-[16px] md:h-[18px] md:leading-[18px]">{review?.pysical_durability}</span>
@@ -160,11 +170,11 @@ const Review = () => {
                     <div className="flex justify-end mb-2">
                       <span className="text-[14px] h-[16px] leading-[16px] pr-1 md:text-[16px] md:h-[18px] md:leading-[18px]">打球感の持続力</span>
                       {review && (
-                          <BarGraph
-                            evaluationVal={review.performance_durability as EvaluationVal}
-                            areaSize="md"
-                            graphHeight="h-[16px] md:h-[18px]"
-                          />
+                        <BarGraph
+                          evaluationVal={review.performance_durability as EvaluationVal}
+                          areaSize="md"
+                          graphHeight="h-[16px] md:h-[18px]"
+                        />
                       )}
                       <span className="inline-block border-r-2 border-sub-green ml-2 mr-1"></span>
                       <span className="inline-block text-[14px] text-center h-[16px] w-6 leading-[16px] md:text-[16px] md:h-[18px] md:leading-[18px]">{review?.performance_durability}</span>

--- a/src/pages/reviews/index.tsx
+++ b/src/pages/reviews/index.tsx
@@ -6,6 +6,7 @@ import AuthCheck from "@/components/AuthCheck";
 import axios from "@/lib/axios";
 import { useRouter } from "next/router";
 import Link from "next/link";
+import Head from 'next/head';
 import Pagination, { Paginator } from "@/components/Pagination";
 import BarGraph, { EvaluationVal } from "@/components/BarGraph";
 import { IoClose } from "react-icons/io5";
@@ -380,6 +381,10 @@ const ReviewList = () => {
       <AuthCheck>
         {isAuth && (
           <>
+            <Head>
+              <title>ストリング・ガットレビュー一覧</title>
+            </Head>
+
             <div className="container mx-auto">
               <div className="mb-6 mt-6 italic md:mb-[32px] md:mt-[32px]">
                 <h1 className="text-center text-[20px] md:text-[32px]">Reviews</h1>

--- a/src/pages/reviews/register.tsx
+++ b/src/pages/reviews/register.tsx
@@ -8,6 +8,7 @@ import Cookies from "js-cookie";
 
 import React, { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import { AuthContext } from "@/context/AuthContext";
 
 import AuthCheck from "@/components/AuthCheck";
@@ -137,7 +138,7 @@ const GutReviewRegister: NextPage = () => {
     const getUserTennisProfile = async () => {
       await axios.get(`api/tennis_profiles/user/${user.id}`).then(res => {
         setUserTennisProfile(res.data);
-        if(res.data.racket) {
+        if (res.data.racket) {
           setRacket(res.data.racket);
         }
       })
@@ -312,7 +313,7 @@ const GutReviewRegister: NextPage = () => {
   }
 
   const afterRegistringRacketHandler = (racket?: Racket) => {
-    if(racket) {
+    if (racket) {
       selectRacket(racket);
     }
   }
@@ -429,6 +430,10 @@ const GutReviewRegister: NextPage = () => {
       <AuthCheck>
         {(isAuth || isAuthAdmin) && (
           <>
+            <Head>
+              <title>ストリング・ガットレビュー投稿</title>
+            </Head>
+
             <div className="container mx-auto mb-6">
               <div className="text-center my-6 md:mb-[32px]">
                 <PrimaryHeading text="Post Review" className="text-[18px] italic h-[20px] md:text-[20px] md:h-[22px]" />
@@ -799,7 +804,7 @@ const GutReviewRegister: NextPage = () => {
                   makers={makers}
                   zIndexClassName="z-50"
                   racketSeries={racketSeries}
-                afterRegistringHandler={afterRegistringRacketHandler}
+                  afterRegistringHandler={afterRegistringRacketHandler}
                 />
 
                 {/* my_equipment検索モーダル */}

--- a/src/pages/users/[id]/edit/base_profile.tsx
+++ b/src/pages/users/[id]/edit/base_profile.tsx
@@ -5,6 +5,7 @@ import Cookies from "js-cookie";
 import { useContext, useRef, useState } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import { useRouter } from "next/router";
+import Head from 'next/head';
 import AuthCheck from "@/components/AuthCheck";
 import ImageCropArea from "@/components/ImageCropArea";
 
@@ -166,6 +167,10 @@ const BaseProfileEdit: NextPage = () => {
       <AuthCheck>
         {isAuth && (
           <>
+            <Head>
+              <title>strii(ストリー) - 基本プロフィール編集</title>
+            </Head>
+
             {/* <h1>プロフィールページ</h1> */}
             <div className="container mx-auto">
               <div className="w-80 mt-[24px] md:w-[500px] mx-auto flex flex-col md:justify-center md:mt-[48px]">

--- a/src/pages/users/[id]/edit/tennis_profile.tsx
+++ b/src/pages/users/[id]/edit/tennis_profile.tsx
@@ -7,6 +7,7 @@ import Cookies from "js-cookie";
 import { useContext, useEffect, useState } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import { useRouter } from "next/router";
+import Head from 'next/head'
 import AuthCheck from "@/components/AuthCheck";
 import { IoClose } from "react-icons/io5";
 import TextUnderBar from "@/components/TextUnderBar";
@@ -117,7 +118,7 @@ const TennisProfileEdit: NextPage = () => {
   }
 
   const afterRegistringRacketHandler = (racket?: Racket) => {
-    if(racket) {
+    if (racket) {
       setRacket(racket)
     }
     setRacketSearchModalVisibility(false);
@@ -314,6 +315,10 @@ const TennisProfileEdit: NextPage = () => {
       <AuthCheck>
         {isAuth && (
           <>
+            <Head>
+              <title>strii(ストリー) - テニスプロフィール編集</title>
+            </Head>
+
             <div className="container mx-auto">
               <div className="w-80 mt-[24px] md:w-[500px] mx-auto flex flex-col md:justify-center md:mt-[48px]">
                 <div className="w-[320px] md:w-[500px] mb-16">

--- a/src/pages/users/[id]/profile.tsx
+++ b/src/pages/users/[id]/profile.tsx
@@ -17,6 +17,7 @@ import AuthCheck from "@/components/AuthCheck";
 import Link from "next/link";
 import axios from "@/lib/axios";
 import { Router, useRouter } from "next/router";
+import Head from 'next/head';
 
 export type Maker = {
   id: number,
@@ -113,6 +114,10 @@ const UserProfile: NextPage = () => {
       <AuthCheck>
         {isAuth && (
           <>
+            <Head>
+              <title>strii(ストリー) - プロフィール</title>
+            </Head>
+
             <div className="container mx-auto">
               <div className="w-80 mt-6  mx-auto flex flex-col md:flex-row md:justify-center md:mt-[48px] md:w-[704px]">
                 <div className="w-[320px] md:mr-[32px]">
@@ -150,12 +155,12 @@ const UserProfile: NextPage = () => {
                     <p className="mb-2 basis-full">使用ラケット</p>
 
                     <div className="w-28 h-40 bg-faint-green">
-                      { tennisProfile?.racket?.racket_image.file_path
+                      {tennisProfile?.racket?.racket_image.file_path
                         ? <img src={`${tennisProfile.racket.racket_image.file_path}`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                         : <img src={`${baseImagePath}images/rackets/default_racket_image.png`} alt="ラケット画像" className="w-[120px] h-[160px]" />
                       }
                     </div>
-                    
+
                     <div className="w-44 flex flex-col">
                       <span className="inline-block pl-2 text-xs mb-2">{tennisProfile?.racket ? tennisProfile?.racket.maker.name_en : ''}</span>
                       <p className="pl-2 leading-[18px] mb-4">{tennisProfile?.racket ? tennisProfile?.racket.name_ja : '未選択'}</p>

--- a/src/pages/users/login.tsx
+++ b/src/pages/users/login.tsx
@@ -7,6 +7,7 @@ import { useContext, useState } from "react";
 import { useRouter } from "next/router";
 import { AuthContext } from "@/context/AuthContext";
 import type { User } from "@/context/AuthContext";
+import Head from 'next/head'
 
 const UserLogin: NextPage = () => {
   const router = useRouter();
@@ -61,6 +62,10 @@ const UserLogin: NextPage = () => {
 
   return (
     <>
+      <Head>
+        <title>strii(ストリー) - ログイン</title>
+      </Head>
+
       <div className="container text-gray-600 px-2 sm:px-5 py-5 mx-auto">
 
         <div className="flex flex-col text-center w-full mb-5">

--- a/src/pages/users/register.tsx
+++ b/src/pages/users/register.tsx
@@ -5,6 +5,7 @@ import Cookies from "js-cookie";
 import { useContext, useState } from "react";
 import { useRouter } from "next/router";
 import { AuthContext } from "@/context/AuthContext";
+import Head from 'next/head'
 
 const UserRegister: NextPage = () => {
   const router = useRouter();
@@ -70,6 +71,10 @@ const UserRegister: NextPage = () => {
 
   return (
     <>
+      <Head>
+        <title>strii(ストリー) - ユーザー登録</title>
+      </Head>
+
       <div className="container text-gray-600 px-2 sm:px-5 py-5 mx-auto">
 
         <div className="flex flex-col text-center w-full mb-5">


### PR DESCRIPTION
issue
#127 

背景
サイトデプロイまで行ったがgoogleの検索でサイトが検索の上位に来なく、urlを直接入力しなければユーザーにサイトに訪れてもらえない状態であった。これを改善するためにgoogleのクローラーbotにサイトの情報を認識させて検索上位にくるようにしたい。そのためにheadタグの中身を適切に調整する

やったこと

- [ ] サイト全体共通のmetaタグのdescriptionとkeywordを設定
- [ ] トップページのtitleタグの設定
- [ ] user関連各ページのtitleタグを設定
- [ ] review関連ページのtitleタグを設定
- [ ] racket関連各ページのtitleタグを設定
- [ ] racket_images関連ページのtitleタグを設定
- [ ] my_equipment関連各ページのtitleタグを設定
- [ ] gut関連各ページのtitleタグを設定
- [ ] gut_images関連ページのtitleタグを設定
- [ ] admins関連各ページのtitleタグを設定

備考
サイトがpagesルーターで作成しているため、Appルーターで書き換える必要が出た場合は動的なHeadタグを別の書き方にしないといけなくなるかもしれない

レビューはコードとブラウザのタブの文字を確認していただければと思います。
インデントの調整の関係で多めに変更箇所がハイライトされているファイルがあります。
レビューお願いします。、